### PR TITLE
feat: 编队预设轮换与泡澡修理系统

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -308,12 +308,24 @@ ipcMain.handle('check-adb-devices', async () => {
   }
 });
 
+ipcMain.on('get-app-version-sync', (event) => {
+  event.returnValue = app.getVersion();
+});
+
 ipcMain.handle('get-app-root', () => {
   return appRoot();
 });
 
 ipcMain.handle('get-plans-dir', () => {
   return resolveAppPath('plans');
+});
+
+ipcMain.handle('list-plan-files', () => {
+  const dir = resolveAppPath('plans');
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter(f => /\.ya?ml$/i.test(f))
+    .map(f => ({ name: f.replace(/\.ya?ml$/i, ''), file: f }));
 });
 
 ipcMain.handle('get-config-dir', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,10 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronBridge', {
+  getAppVersion: () => {
+    return ipcRenderer.sendSync('get-app-version-sync') as string;
+  },
+
   openDirectoryDialog: (title?: string) => {
     return ipcRenderer.invoke('open-directory-dialog', title);
   },
@@ -42,6 +46,10 @@ contextBridge.exposeInMainWorld('electronBridge', {
 
   getPlansDir: () => {
     return ipcRenderer.invoke('get-plans-dir');
+  },
+
+  listPlanFiles: () => {
+    return ipcRenderer.invoke('list-plan-files');
   },
 
   getConfigDir: () => {

--- a/resource/builtin_templates.json
+++ b/resource/builtin_templates.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "builtin_farm_loot",
+    "name": "刷胖次",
+    "type": "normal_fight",
+    "builtin": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "description": "自动刷取战利品（胖次），可选择不同地图方案",
+    "planPaths": [
+      "plans/9-2捞胖次.yaml",
+      "plans/7-4千伪.yaml",
+      "plans/8-5AI.yaml",
+      "plans/2-1捞胖次挂机.yaml"
+    ],
+    "defaultTimes": 99,
+    "defaultStopCondition": {
+      "loot_count_ge": 50
+    }
+  },
+  {
+    "id": "builtin_exercise",
+    "name": "自动演习",
+    "type": "exercise",
+    "builtin": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "description": "每日自动完成演习",
+    "fleet_id": 1,
+    "defaultTimes": 1
+  },
+  {
+    "id": "builtin_campaign",
+    "name": "战役",
+    "type": "campaign",
+    "builtin": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "description": "自动完成战役，使用时选择具体战役类型",
+    "campaign_name": "困难潜艇",
+    "defaultTimes": 1
+  },
+  {
+    "id": "builtin_decisive_6",
+    "name": "决战第6章",
+    "type": "decisive",
+    "builtin": true,
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "description": "自动完成决战第6章",
+    "chapter": 6,
+    "level1": [],
+    "level2": [],
+    "flagship_priority": [],
+    "defaultTimes": 1
+  }
+]

--- a/src/controller/AppController.ts
+++ b/src/controller/AppController.ts
@@ -69,6 +69,7 @@ interface ElectronBridge {
   getAppRoot: () => Promise<string>;
   getPlansDir: () => Promise<string>;
   getConfigDir: () => Promise<string>;
+  listPlanFiles: () => Promise<{ name: string; file: string }[]>;
   openFolder: (folderPath: string) => Promise<void>;
   checkEnvironment: () => Promise<{
     pythonCmd: string | null;
@@ -94,6 +95,7 @@ interface ElectronBridge {
   onUpdateStatus: (callback: (status: any) => void) => void;
   onBackendLog: (callback: (line: string) => void) => void;
   onSetupLog: (callback: (text: string) => void) => void;
+  getAppVersion: () => string;
 }
 
 declare global {
@@ -147,6 +149,10 @@ export class AppController {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private editingNodeId: string | null = null;
   private wizardStep = 1;
+  /** 向导中多方案路径列表 */
+  private wizardPlanPaths: string[] = [];
+  /** 正在编辑的模板 ID（非空时向导为编辑模式） */
+  private editingTemplateId: string | null = null;
   private currentPreset: TaskPreset | null = null;
   private currentPresetFilePath = '';
 
@@ -169,6 +175,7 @@ export class AppController {
       autoBattle: cfg.auto_battle,
       battleType: cfg.battle_type,
       battleTimes: cfg.battle_times,
+      autoNormalFight: cfg.auto_normal_fight,
     });
   }
 
@@ -184,6 +191,14 @@ export class AppController {
     this.bindOpsActions();
     this.renderMain();
     this.planView.render(null);
+
+    // 显示版本号
+    const versionEl = document.getElementById('app-version');
+    const bridge = window.electronBridge;
+    if (versionEl && bridge) {
+      const v = bridge.getAppVersion();
+      if (v) versionEl.textContent = `v${v}`;
+    }
 
     // 监听系统主题变化
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -226,7 +241,7 @@ export class AppController {
         const time = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
         this.mainView.appendLog({ time, level, channel, message });
       },
-      logDir: this.configDir,
+      logDir: `${this.configDir}/log`,
     });
 
     // 显示关键路径，帮助用户找到配置和方案目录
@@ -243,14 +258,15 @@ export class AppController {
       autoBattle: da.auto_battle,
       battleType: da.battle_type,
       battleTimes: da.battle_times,
+      autoNormalFight: da.auto_normal_fight,
     });
     await this.detectAndApplyEmulator();
     Logger.debug('模拟器检测完成');
+
+    // 加载模板（需在 renderConfig 之前，以便决战模板下拉列表能检索到已有模板）
+    await this.templateModel.init(bridge);
     this.renderConfig();
     this.mainView.setDebugMode(localStorage.getItem('debugMode') === 'true');
-
-    // 加载模板
-    await this.templateModel.init(bridge);
     this.renderTemplateLibrary();
 
     // 加载任务组
@@ -1019,7 +1035,24 @@ export class AppController {
 
     return Promise.all(items.map(async (item): Promise<TaskGroupItemMeta | null> => {
       try {
-        const content = await bridge.readFile(item.path);
+        // 模板引用 — 从模板库读取元数据
+        if (item.kind === 'template') {
+          const tpl = this.templateModel.get(item.templateId ?? '');
+          if (!tpl) return { typeLabel: '模板已删除' };
+          const meta: TaskGroupItemMeta = {
+            typeLabel: TYPE_LABELS[tpl.type] ?? tpl.type,
+          };
+          if (tpl.fleet_id) meta.fleetId = tpl.fleet_id;
+          if (item.fleet_id) meta.fleetId = item.fleet_id;
+          if (tpl.fleet?.length) meta.fleet = tpl.fleet.filter(Boolean);
+          if (item.campaignName) meta.mapName = item.campaignName;
+          else if (tpl.campaign_name) meta.mapName = tpl.campaign_name;
+          if (item.chapter) meta.mapName = `决战第${item.chapter}章`;
+          else if (tpl.chapter) meta.mapName = `决战第${tpl.chapter}章`;
+          return meta;
+        }
+
+        const content = await bridge.readFile(item.path!);
         const parsed = (await import('js-yaml')).load(content) as Record<string, unknown>;
         if (!parsed || typeof parsed !== 'object') return null;
 
@@ -1206,15 +1239,21 @@ export class AppController {
     let loadedCount = 0;
     for (const item of group.items) {
       try {
-        const content = await bridge.readFile(item.path);
+        if (item.kind === 'template') {
+          // 模板引用 — 直接从模板库构建任务请求
+          loadedCount += this.loadTemplateToQueue(item) ? 1 : 0;
+          continue;
+        }
+
+        const content = await bridge.readFile(item.path!);
         const parsed = (await import('js-yaml')).load(content) as Record<string, unknown>;
         if (!parsed || typeof parsed !== 'object') continue;
 
         if (item.kind === 'preset' || ('task_type' in parsed && !('chapter' in parsed))) {
-          this.importTaskPreset(parsed as unknown as TaskPreset, item.path);
+          this.importTaskPreset(parsed as unknown as TaskPreset, item.path!);
         } else {
           // 战斗方案
-          const plan = PlanModel.fromYaml(content, item.path);
+          const plan = PlanModel.fromYaml(content, item.path!);
           const times = item.times;
           const req: NormalFightReq = {
             type: 'normal_fight',
@@ -1238,6 +1277,44 @@ export class AppController {
     }
   }
 
+  /** 从模板 ID 构建任务请求并加入调度队列 */
+  private loadTemplateToQueue(item: import('../model/TaskGroupModel').TaskGroupItem): boolean {
+    const tpl = this.templateModel.get(item.templateId ?? '');
+    if (!tpl) {
+      Logger.error(`模板「${item.label}」不存在，可能已被删除`);
+      return false;
+    }
+
+    let req: TaskRequest;
+    const times = item.times;
+
+    switch (tpl.type) {
+      case 'exercise':
+        req = { type: 'exercise', fleet_id: item.fleet_id ?? tpl.fleet_id ?? 1 };
+        this.scheduler.addTask(item.label || tpl.name, 'exercise', req, TaskPriority.USER_TASK, 1);
+        break;
+      case 'campaign': {
+        const cName = item.campaignName ?? tpl.campaign_name ?? '困难潜艇';
+        req = { type: 'campaign', campaign_name: cName, times: 1 };
+        this.scheduler.addTask(item.label || tpl.name, 'campaign', req, TaskPriority.USER_TASK, times);
+        break;
+      }
+      case 'decisive':
+        req = {
+          type: 'decisive',
+          chapter: item.chapter ?? tpl.chapter ?? 6,
+          level1: tpl.level1 ?? [],
+          level2: tpl.level2 ?? [],
+          flagship_priority: tpl.flagship_priority ?? [],
+        };
+        this.scheduler.addTask(item.label || tpl.name, 'decisive', req, TaskPriority.USER_TASK, 1);
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+
   /** 从任务列表拖拽单个条目加入队列 */
   private async loadSingleItemToQueue(index: number): Promise<void> {
     const group = this.taskGroupModel.getActiveGroup();
@@ -1245,18 +1322,25 @@ export class AppController {
     const item = group.items[index];
     if (!item) return;
 
+    if (item.kind === 'template') {
+      this.loadTemplateToQueue(item);
+      Logger.info(`已将「${item.label}」加入队列`);
+      this.renderMain();
+      return;
+    }
+
     const bridge = window.electronBridge;
     if (!bridge) return;
 
     try {
-      const content = await bridge.readFile(item.path);
+      const content = await bridge.readFile(item.path!);
       const parsed = (await import('js-yaml')).load(content) as Record<string, unknown>;
       if (!parsed || typeof parsed !== 'object') return;
 
       if (item.kind === 'preset' || ('task_type' in parsed && !('chapter' in parsed))) {
-        this.importTaskPreset(parsed as unknown as TaskPreset, item.path);
+        this.importTaskPreset(parsed as unknown as TaskPreset, item.path!);
       } else {
-        const plan = PlanModel.fromYaml(content, item.path);
+        const plan = PlanModel.fromYaml(content, item.path!);
         const req: NormalFightReq = {
           type: 'normal_fight',
           plan_id: plan.fileName,
@@ -1304,7 +1388,11 @@ export class AppController {
       if (!group) return;
       const item = group.items[target.id as number];
       if (!item) return;
-      await this.openItemForEdit(item.path, item.kind);
+      if (item.kind === 'template') {
+        Logger.info(`模板「${item.label}」请在模板库中查看和编辑`);
+        return;
+      }
+      await this.openItemForEdit(item.path!, item.kind);
     } else {
       // 从队列中查找任务
       const taskId = target.id as string;
@@ -1768,11 +1856,9 @@ export class AppController {
     const times = plan.data.times ?? 1;
     const stopCondition = plan.data.stop_condition;
 
-    // 检查是否选中了编队预设
-    const presetIdx = this.planView.selectedFleetPresetIndex;
-    const selectedFleet = (presetIdx >= 0 && plan.data.fleet_presets)
-      ? plan.data.fleet_presets[presetIdx]?.ships
-      : undefined;
+    // 检查选中的编队预设（多选）
+    const selectedPresets = this.planView.getSelectedPresets();
+    const firstPreset = selectedPresets.length > 0 ? selectedPresets[0] : undefined;
 
     const req: NormalFightReq = {
       type: 'normal_fight',
@@ -1781,13 +1867,20 @@ export class AppController {
       gap: plan.data.gap ?? 0,
     };
 
-    // 如果选中了编队预设，将舰船列表附加到请求中（转换为后端名称）
-    if (selectedFleet && selectedFleet.length > 0) {
+    // 如果选中了编队预设，使用第一个预设的舰船列表
+    if (firstPreset && firstPreset.ships.length > 0) {
       req.plan = {
-        fleet: selectedFleet.map(toBackendName),
+        fleet: firstPreset.ships.map(toBackendName),
         fleet_id: plan.data.fleet_id,
       };
     }
+
+    // 读取泡澡修理配置
+    const bathRepairConfig = this.planView.getBathRepairConfig();
+    const fleetId = plan.data.fleet_id ?? 1;
+    // 编队预设轮换: 选中多个预设时传递所有选中的预设
+    const fleetPresets = selectedPresets.length > 1 ? selectedPresets : undefined;
+    const currentPresetIndex = fleetPresets ? 0 : undefined;
 
     this.scheduler.addTask(
       plan.mapName,
@@ -1796,11 +1889,15 @@ export class AppController {
       TaskPriority.USER_TASK,
       times,
       stopCondition,
+      bathRepairConfig,
+      fleetId,
+      fleetPresets,
+      currentPresetIndex,
     );
-    Logger.debug(`executePlan: map=${plan.mapName} plan_id=${plan.fileName} times=${times} gap=${req.gap}${selectedFleet ? ' fleet=' + selectedFleet.join(',') : ''}`);
+    Logger.debug(`executePlan: map=${plan.mapName} plan_id=${plan.fileName} times=${times} gap=${req.gap}${firstPreset ? ' fleet=' + firstPreset.ships.join(',') : ''}${fleetPresets ? ' rotation=' + fleetPresets.length + '套' : ''}`);
 
     // 重置编队选择
-    this.planView.selectedFleetPresetIndex = -1;
+    this.planView.selectedFleetPresetIndices.clear();
 
     this.switchPage('main');
     this.renderMain();
@@ -2251,11 +2348,16 @@ export class AppController {
       battleTimes: cfg.daily_automation.battle_times,
       autoNormalFight: cfg.daily_automation.auto_normal_fight,
       autoDecisive: cfg.daily_automation.auto_decisive,
+      decisiveTicketReserve: cfg.daily_automation.decisive_ticket_reserve,
+      decisiveTemplateId: cfg.daily_automation.decisive_template_id,
       themeMode: this.getThemeMode(),
       accentColor: this.getAccentColor(),
       debugMode: localStorage.getItem('debugMode') === 'true',
     };
     this.configView.render(vo);
+
+    // 填充决战模板下拉列表（传入配置值，因为 render 时 option 尚不存在，浏览器会静默丢弃）
+    this.populateDecisiveTemplateSelect(cfg.daily_automation.decisive_template_id);
   }
 
   private async saveConfig(): Promise<void> {
@@ -2285,6 +2387,8 @@ export class AppController {
         battle_times: collected.battleTimes,
         auto_normal_fight: collected.autoNormalFight,
         auto_decisive: collected.autoDecisive,
+        decisive_ticket_reserve: collected.decisiveTicketReserve,
+        decisive_template_id: collected.decisiveTemplateId,
       },
     });
 
@@ -2296,6 +2400,7 @@ export class AppController {
       autoBattle: da.auto_battle,
       battleType: da.battle_type,
       battleTimes: da.battle_times,
+      autoNormalFight: da.auto_normal_fight,
     });
 
     // 同步远征检查间隔
@@ -2310,6 +2415,17 @@ export class AppController {
     }
   }
 
+  /** 填充配置页的决战模板下拉列表 */
+  private populateDecisiveTemplateSelect(selectedId?: string): void {
+    const sel = document.getElementById('cfg-decisive-template') as HTMLSelectElement | null;
+    if (!sel) return;
+    const desiredVal = selectedId ?? sel.value;
+    const decisiveTemplates = this.templateModel.getAll().filter(t => t.type === 'decisive');
+    sel.innerHTML = '<option value="">未选择</option>' +
+      decisiveTemplates.map(t => `<option value="${t.id}">${t.name}</option>`).join('');
+    sel.value = desiredVal;
+  }
+
   // ════════════════════════════════════════
   // 模板系统
   // ════════════════════════════════════════
@@ -2320,6 +2436,11 @@ export class AppController {
     campaign: '战役',
     decisive: '决战',
   };
+
+  private static readonly CAMPAIGN_OPTIONS: string[] = [
+    '困难潜艇', '困难航母', '困难驱逐', '困难巡洋', '困难战列',
+    '简单航母', '简单潜艇', '简单驱逐', '简单巡洋', '简单战列',
+  ];
 
   private bindTemplateActions(): void {
     // 创建模板按钮
@@ -2338,7 +2459,7 @@ export class AppController {
       radio.addEventListener('change', () => this.updateWizardConfigPanel());
     });
 
-    // 步骤2：浏览方案文件
+    // 步骤2：浏览添加方案文件
     document.getElementById('btn-tpl-browse-plan')?.addEventListener('click', async () => {
       const bridge = window.electronBridge;
       if (!bridge) return;
@@ -2346,8 +2467,69 @@ export class AppController {
         [{ name: 'YAML 方案', extensions: ['yaml', 'yml'] }],
         this.plansDir || undefined,
       );
-      if (result) {
-        (document.getElementById('tpl-plan-path') as HTMLInputElement).value = result.path;
+      if (!result) return;
+      const filePath = result.path;
+      if (!this.wizardPlanPaths.includes(filePath)) {
+        this.wizardPlanPaths.push(filePath);
+        this.renderWizardPlanList();
+      }
+      (document.getElementById('tpl-plan-path') as HTMLInputElement).value = filePath;
+      if (this.wizardPlanPaths.length === 1) {
+        try {
+          const parsed = (await import('js-yaml')).load(result.content) as Record<string, any>;
+          if (!parsed || typeof parsed !== 'object') return;
+          if (parsed.fleet_id) {
+            (document.getElementById('tpl-fleet') as HTMLSelectElement).value = String(parsed.fleet_id);
+          }
+          const presets = parsed.fleet_presets as any[] | undefined;
+          if (presets?.length && presets[0].ships?.length) {
+            this.fillFleetGrid('nf', presets[0].ships);
+          }
+          const sc = parsed.stop_condition as any;
+          if (sc) {
+            if (sc.loot_count_ge != null && sc.loot_count_ge >= 0) {
+              (document.getElementById('tpl-stop-loot') as HTMLInputElement).value = String(sc.loot_count_ge);
+            }
+            if (sc.ship_count_ge != null && sc.ship_count_ge >= 0) {
+              (document.getElementById('tpl-stop-ship') as HTMLInputElement).value = String(sc.ship_count_ge);
+            }
+          }
+          const fileName = filePath.split(/[\\/]/).pop()?.replace(/\.ya?ml$/i, '') ?? '';
+          if (fileName) {
+            (document.getElementById('tpl-name') as HTMLInputElement).value = fileName;
+          }
+          if (parsed.times) {
+            (document.getElementById('tpl-default-times') as HTMLInputElement).value = String(parsed.times);
+          }
+        } catch { /* YAML 解析失败不影响流程 */ }
+      }
+    });
+
+    // 步骤2：从方案目录扫描添加
+    document.getElementById('btn-tpl-scan-plans')?.addEventListener('click', async () => {
+      const bridge = window.electronBridge;
+      if (!bridge?.listPlanFiles) return;
+      const files = await bridge.listPlanFiles();
+      let added = 0;
+      for (const f of files) {
+        const fullPath = `${this.plansDir}\\${f.file}`;
+        if (!this.wizardPlanPaths.includes(fullPath)) {
+          this.wizardPlanPaths.push(fullPath);
+          added++;
+        }
+      }
+      if (added > 0) this.renderWizardPlanList();
+      Logger.info(`扫描到 ${files.length} 个方案文件，新增 ${added} 个`);
+    });
+
+    // 步骤2：方案列表删除按钮
+    document.getElementById('tpl-plan-list')?.addEventListener('click', (e) => {
+      const btn = (e.target as HTMLElement).closest('.btn-remove-plan') as HTMLElement | null;
+      if (!btn) return;
+      const idx = parseInt(btn.dataset.idx ?? '-1');
+      if (idx >= 0 && idx < this.wizardPlanPaths.length) {
+        this.wizardPlanPaths.splice(idx, 1);
+        this.renderWizardPlanList();
       }
     });
 
@@ -2373,6 +2555,7 @@ export class AppController {
       if (action === 'use') this.useTemplate(id);
       else if (action === 'delete') this.deleteTemplate(id);
       else if (action === 'rename') this.renameTemplate(id);
+      else if (action === 'edit') this.editTemplate(id);
     });
 
     // 初始渲染模板库
@@ -2383,6 +2566,8 @@ export class AppController {
 
   private showWizard(): void {
     this.wizardStep = 1;
+    this.wizardPlanPaths = [];
+    this.editingTemplateId = null;
     // 重置表单
     (document.querySelector('input[name="tpl-type"][value="normal_fight"]') as HTMLInputElement).checked = true;
     (document.getElementById('tpl-plan-path') as HTMLInputElement).value = '';
@@ -2390,6 +2575,7 @@ export class AppController {
     (document.getElementById('tpl-default-times') as HTMLInputElement).value = '1';
     (document.getElementById('tpl-stop-loot') as HTMLInputElement).value = '-1';
     (document.getElementById('tpl-stop-ship') as HTMLInputElement).value = '-1';
+    this.renderWizardPlanList();
     // 重置编队设置
     for (const suffix of ['nf', 'ex', 'cp']) {
       const cb = document.getElementById(`tpl-fleet-enable-${suffix}`) as HTMLInputElement | null;
@@ -2421,7 +2607,12 @@ export class AppController {
     // 预填类型专属字段
     switch (type) {
       case 'normal_fight': {
-        if (tpl.planPath) (document.getElementById('tpl-plan-path') as HTMLInputElement).value = tpl.planPath;
+        if (tpl.planPaths?.length) {
+          this.wizardPlanPaths = [...tpl.planPaths];
+        } else if (tpl.planPath) {
+          this.wizardPlanPaths = [tpl.planPath];
+        }
+        this.renderWizardPlanList();
         if (tpl.fleet_id) (document.getElementById('tpl-fleet') as HTMLSelectElement).value = String(tpl.fleet_id);
         if (tpl.fleet?.length) this.fillFleetGrid('nf', tpl.fleet);
         break;
@@ -2476,6 +2667,23 @@ export class AppController {
 
   private hideWizard(): void {
     document.getElementById('template-wizard')!.style.display = 'none';
+  }
+
+  /** 渲染向导中的多方案列表 */
+  private renderWizardPlanList(): void {
+    const container = document.getElementById('tpl-plan-list');
+    if (!container) return;
+    if (this.wizardPlanPaths.length === 0) {
+      container.innerHTML = '<p style="color:var(--text-muted);font-size:12px;margin:0">尚未添加方案文件</p>';
+      return;
+    }
+    container.innerHTML = this.wizardPlanPaths.map((p, i) => {
+      const name = p.split(/[\\/]/).pop()?.replace(/\.ya?ml$/i, '') ?? p;
+      return `<div class="tpl-plan-entry">
+        <span class="plan-name" title="${p}">${name}</span>
+        <span class="btn-remove-plan" data-idx="${i}" title="移除">✕</span>
+      </div>`;
+    }).join('');
   }
 
   // ── 向导导航 ──
@@ -2651,13 +2859,16 @@ export class AppController {
     }
 
     const times = parseInt((document.getElementById('tpl-default-times') as HTMLInputElement).value) || 1;
-    const loot = parseInt((document.getElementById('tpl-stop-loot') as HTMLInputElement).value) || 0;
-    const ship = parseInt((document.getElementById('tpl-stop-ship') as HTMLInputElement).value) || 0;
 
-    const stopCondition = (loot > 0 || ship > 0) ? {
-      ...(loot > 0 ? { loot_count_ge: loot } : {}),
-      ...(ship > 0 ? { ship_count_ge: ship } : {}),
-    } : undefined;
+    let stopCondition: TaskTemplate['defaultStopCondition'];
+    if (type !== 'decisive') {
+      const loot = parseInt((document.getElementById('tpl-stop-loot') as HTMLInputElement).value) || 0;
+      const ship = parseInt((document.getElementById('tpl-stop-ship') as HTMLInputElement).value) || 0;
+      stopCondition = (loot > 0 || ship > 0) ? {
+        ...(loot > 0 ? { loot_count_ge: loot } : {}),
+        ...(ship > 0 ? { ship_count_ge: ship } : {}),
+      } : undefined;
+    }
 
     const partial: Omit<TaskTemplate, 'id' | 'createdAt'> = {
       name,
@@ -2669,14 +2880,17 @@ export class AppController {
     // 类型专属字段
     switch (type) {
       case 'normal_fight': {
-        const planPath = (document.getElementById('tpl-plan-path') as HTMLInputElement).value;
-        if (!planPath) {
-          this.wizardStep = 2;
-          this.updateWizardUI();
-          (document.getElementById('tpl-plan-path') as HTMLInputElement).focus();
-          return;
+        if (this.wizardPlanPaths.length === 0) {
+          const planPath = (document.getElementById('tpl-plan-path') as HTMLInputElement).value;
+          if (!planPath) {
+            this.wizardStep = 2;
+            this.updateWizardUI();
+            return;
+          }
+          this.wizardPlanPaths = [planPath];
         }
-        partial.planPath = planPath;
+        partial.planPaths = [...this.wizardPlanPaths];
+        partial.planPath = this.wizardPlanPaths[0];
         partial.fleet_id = parseInt((document.getElementById('tpl-fleet') as HTMLSelectElement).value);
         partial.fleet = this.readFleetGrid('nf');
         break;
@@ -2700,78 +2914,280 @@ export class AppController {
       }
     }
 
-    await this.templateModel.add(partial);
+    if (this.editingTemplateId) {
+      await this.templateModel.update(this.editingTemplateId, partial);
+      Logger.info(`模板「${name}」已更新`);
+      this.editingTemplateId = null;
+    } else {
+      await this.templateModel.add(partial);
+      Logger.info(`模板「${name}」已创建`);
+    }
     this.hideWizard();
     this.renderTemplateLibrary();
-    Logger.info(`模板「${name}」已创建`);
   }
 
-  // ── 使用模板 → 加入任务队列 ──
+  // ── 使用模板 → 加入任务列表 ──
 
   private async useTemplate(id: string): Promise<void> {
     const tpl = this.templateModel.get(id);
     if (!tpl) return;
 
-    const times = tpl.defaultTimes ?? 1;
-
-    let req: TaskRequest;
-    switch (tpl.type) {
-      case 'exercise':
-        req = { type: 'exercise', fleet_id: tpl.fleet_id ?? 1 };
-        break;
-      case 'campaign':
-        req = { type: 'campaign', campaign_name: tpl.campaign_name ?? '困难潜艇', times: 1 };
-        break;
-      case 'decisive':
-        req = {
-          type: 'decisive',
-          chapter: tpl.chapter ?? 6,
-          level1: tpl.level1 ?? [],
-          level2: tpl.level2 ?? [],
-          flagship_priority: tpl.flagship_priority ?? [],
-        };
-        break;
-      case 'normal_fight':
-      default:
-        if (tpl.fleet?.length) {
-          req = {
-            type: 'normal_fight',
-            plan: {
-              fleet_id: tpl.fleet_id ?? 1,
-              fleet: tpl.fleet,
-            },
-            plan_id: tpl.planPath ?? null,
-            times: 1,
-            gap: tpl.defaultGap ?? 0,
-          };
-        } else {
-          req = {
-            type: 'normal_fight',
-            plan_id: tpl.planPath ?? null,
-            times: 1,
-            gap: tpl.defaultGap ?? 0,
-          };
-        }
-        break;
+    let group = this.taskGroupModel.getActiveGroup();
+    if (!group) {
+      this.taskGroupModel.upsertGroup('默认');
+      this.taskGroupModel.setActiveGroup('默认');
+      group = this.taskGroupModel.getActiveGroup()!;
     }
 
-    const effectiveTimes = (tpl.type === 'exercise' || tpl.type === 'decisive') ? 1 : times;
-    // campaign: 后端只执行单次，前端通过 follow-up 管理重复次数
+    if (tpl.type === 'normal_fight') {
+      const paths = tpl.planPaths ?? (tpl.planPath ? [tpl.planPath] : []);
+      if (paths.length === 0) {
+        Logger.warn(`模板「${tpl.name}」缺少方案文件路径`);
+        return;
+      }
+      if (paths.length === 1) {
+        this.addPlanToTaskList(tpl, paths[0], group.name);
+      } else {
+        this.showPlanSelector(tpl, paths, group.name);
+        return;
+      }
+    } else if (tpl.type === 'campaign') {
+      this.showCampaignSelector(tpl, group.name);
+      return;
+    } else if (tpl.type === 'exercise') {
+      this.showExerciseFleetSelector(tpl, group.name);
+      return;
+    } else if (tpl.type === 'decisive') {
+      this.showDecisiveChapterSelector(tpl, group.name);
+      return;
+    } else {
+      this.taskGroupModel.addItem(group.name, {
+        templateId: tpl.id,
+        kind: 'template',
+        times: tpl.defaultTimes ?? 1,
+        label: tpl.name,
+      });
+    }
 
-    this.scheduler.addTask(
-      tpl.name,
-      tpl.type,
-      req,
-      TaskPriority.USER_TASK,
-      effectiveTimes,
-      tpl.defaultStopCondition,
-    );
+    this.taskGroupModel.save();
+    this.renderTaskGroup();
+    Logger.info(`模板「${tpl.name}」→ 已加入任务列表「${group.name}」`);
+  }
 
-    this.renderMain();
-    Logger.info(`模板「${tpl.name}」→ 任务已加入队列 (×${effectiveTimes})`);
+  /** 将指定方案添加到任务列表 */
+  private addPlanToTaskList(tpl: TaskTemplate, planPath: string, groupName: string): void {
+    const planName = planPath.split(/[\\/]/).pop()?.replace(/\.ya?ml$/i, '') ?? tpl.name;
+    this.taskGroupModel.addItem(groupName, {
+      path: planPath,
+      kind: 'plan',
+      times: tpl.defaultTimes ?? 1,
+      label: `${tpl.name} (${planName})`,
+    });
+  }
+
+  /** 显示方案选择弹窗 */
+  private showPlanSelector(tpl: TaskTemplate, paths: string[], groupName: string): void {
+    const overlay = document.getElementById('plan-selector-dialog')!;
+    const title = document.getElementById('plan-selector-title')!;
+    const list = document.getElementById('plan-selector-list')!;
+    const timesRow = document.getElementById('plan-selector-times-row')!;
+    timesRow.style.display = 'none';
+
+    title.textContent = `「${tpl.name}」— 选择执行方案`;
+    list.innerHTML = paths.map((p, i) => {
+      const name = p.split(/[\\/]/).pop()?.replace(/\.ya?ml$/i, '') ?? p;
+      return `<div class="plan-selector-item" data-plan-idx="${i}">
+        <span class="plan-icon">📄</span>
+        <span>${name}</span>
+      </div>`;
+    }).join('');
+
+    const onSelect = (e: Event) => {
+      const item = (e.target as HTMLElement).closest('.plan-selector-item') as HTMLElement | null;
+      if (!item) return;
+      const idx = parseInt(item.dataset.planIdx ?? '-1');
+      if (idx < 0 || idx >= paths.length) return;
+      this.addPlanToTaskList(tpl, paths[idx], groupName);
+      this.taskGroupModel.save();
+      this.renderTaskGroup();
+      Logger.info(`模板「${tpl.name}」→ 已加入任务列表「${groupName}」（方案: ${paths[idx].split(/[\\/]/).pop()}）`);
+      cleanup();
+    };
+    const onCancel = () => cleanup();
+    const cleanup = () => {
+      overlay.style.display = 'none';
+      list.removeEventListener('click', onSelect);
+      document.getElementById('btn-plan-selector-cancel')?.removeEventListener('click', onCancel);
+    };
+
+    list.addEventListener('click', onSelect);
+    document.getElementById('btn-plan-selector-cancel')?.addEventListener('click', onCancel);
+    overlay.style.display = 'flex';
+  }
+
+  private showCampaignSelector(tpl: TaskTemplate, groupName: string): void {
+    const overlay = document.getElementById('plan-selector-dialog')!;
+    const title = document.getElementById('plan-selector-title')!;
+    const list = document.getElementById('plan-selector-list')!;
+    const timesRow = document.getElementById('plan-selector-times-row')!;
+    const timesInput = document.getElementById('plan-selector-times') as HTMLInputElement;
+    timesRow.style.display = '';
+    timesInput.value = String(tpl.defaultTimes ?? 1);
+
+    title.textContent = `「${tpl.name}」— 选择战役类型`;
+    list.innerHTML = AppController.CAMPAIGN_OPTIONS.map((name, i) => {
+      return `<div class="plan-selector-item" data-plan-idx="${i}">
+        <span class="plan-icon">⚔</span>
+        <span>${name}</span>
+      </div>`;
+    }).join('');
+
+    const onSelect = (e: Event) => {
+      const item = (e.target as HTMLElement).closest('.plan-selector-item') as HTMLElement | null;
+      if (!item) return;
+      const idx = parseInt(item.dataset.planIdx ?? '-1');
+      const chosen = AppController.CAMPAIGN_OPTIONS[idx];
+      if (!chosen) return;
+      const times = parseInt(timesInput.value) || 1;
+      this.taskGroupModel.addItem(groupName, {
+        templateId: tpl.id,
+        kind: 'template',
+        times,
+        label: `${tpl.name} (${chosen})`,
+        campaignName: chosen,
+      });
+      this.taskGroupModel.save();
+      this.renderTaskGroup();
+      Logger.info(`模板「${tpl.name}」→ 已加入任务列表「${groupName}」（${chosen}）`);
+      cleanup();
+    };
+    const onCancel = () => cleanup();
+    const cleanup = () => {
+      overlay.style.display = 'none';
+      list.removeEventListener('click', onSelect);
+      document.getElementById('btn-plan-selector-cancel')?.removeEventListener('click', onCancel);
+    };
+
+    list.addEventListener('click', onSelect);
+    document.getElementById('btn-plan-selector-cancel')?.addEventListener('click', onCancel);
+    overlay.style.display = 'flex';
+  }
+
+  private showExerciseFleetSelector(tpl: TaskTemplate, groupName: string): void {
+    const overlay = document.getElementById('plan-selector-dialog')!;
+    const title = document.getElementById('plan-selector-title')!;
+    const list = document.getElementById('plan-selector-list')!;
+    const timesRow = document.getElementById('plan-selector-times-row')!;
+    timesRow.style.display = 'none';
+
+    title.textContent = `「${tpl.name}」— 选择舰队`;
+    const fleetOptions = ['第 1 舰队', '第 2 舰队', '第 3 舰队', '第 4 舰队'];
+    list.innerHTML = fleetOptions.map((name, i) => {
+      return `<div class="plan-selector-item" data-plan-idx="${i}">
+        <span class="plan-icon">⚓</span>
+        <span>${name}</span>
+      </div>`;
+    }).join('');
+
+    const onSelect = (e: Event) => {
+      const item = (e.target as HTMLElement).closest('.plan-selector-item') as HTMLElement | null;
+      if (!item) return;
+      const idx = parseInt(item.dataset.planIdx ?? '-1');
+      if (idx < 0 || idx >= fleetOptions.length) return;
+      const fleetId = idx + 1;
+      this.taskGroupModel.addItem(groupName, {
+        templateId: tpl.id,
+        kind: 'template',
+        times: tpl.defaultTimes ?? 1,
+        label: `${tpl.name} (${fleetOptions[idx]})`,
+        fleet_id: fleetId,
+      });
+      this.taskGroupModel.save();
+      this.renderTaskGroup();
+      Logger.info(`模板「${tpl.name}」→ 已加入任务列表「${groupName}」（${fleetOptions[idx]}）`);
+      cleanup();
+    };
+    const onCancel = () => cleanup();
+    const cleanup = () => {
+      overlay.style.display = 'none';
+      list.removeEventListener('click', onSelect);
+      document.getElementById('btn-plan-selector-cancel')?.removeEventListener('click', onCancel);
+    };
+
+    list.addEventListener('click', onSelect);
+    document.getElementById('btn-plan-selector-cancel')?.addEventListener('click', onCancel);
+    overlay.style.display = 'flex';
+  }
+
+  private static readonly DECISIVE_CHAPTERS = [
+    { value: 1, label: '第 1 章' },
+    { value: 2, label: '第 2 章' },
+    { value: 3, label: '第 3 章' },
+    { value: 4, label: '第 4 章' },
+    { value: 5, label: '第 5 章' },
+    { value: 6, label: '第 6 章' },
+  ];
+
+  private showDecisiveChapterSelector(tpl: TaskTemplate, groupName: string): void {
+    const overlay = document.getElementById('plan-selector-dialog')!;
+    const title = document.getElementById('plan-selector-title')!;
+    const list = document.getElementById('plan-selector-list')!;
+    const timesRow = document.getElementById('plan-selector-times-row')!;
+    const timesInput = document.getElementById('plan-selector-times') as HTMLInputElement;
+    timesRow.style.display = '';
+    timesInput.value = String(tpl.defaultTimes ?? 1);
+
+    title.textContent = `「${tpl.name}」— 选择章节`;
+    list.innerHTML = AppController.DECISIVE_CHAPTERS.map((ch, i) => {
+      return `<div class="plan-selector-item" data-plan-idx="${i}">
+        <span class="plan-icon">🏆</span>
+        <span>${ch.label}</span>
+      </div>`;
+    }).join('');
+
+    const onSelect = (e: Event) => {
+      const item = (e.target as HTMLElement).closest('.plan-selector-item') as HTMLElement | null;
+      if (!item) return;
+      const idx = parseInt(item.dataset.planIdx ?? '-1');
+      const chosen = AppController.DECISIVE_CHAPTERS[idx];
+      if (!chosen) return;
+      const times = parseInt(timesInput.value) || 1;
+      this.taskGroupModel.addItem(groupName, {
+        templateId: tpl.id,
+        kind: 'template',
+        times,
+        label: `${tpl.name} (${chosen.label})`,
+        chapter: chosen.value,
+      });
+      this.taskGroupModel.save();
+      this.renderTaskGroup();
+      Logger.info(`模板「${tpl.name}」→ 已加入任务列表「${groupName}」（${chosen.label}）`);
+      cleanup();
+    };
+    const onCancel = () => cleanup();
+    const cleanup = () => {
+      overlay.style.display = 'none';
+      list.removeEventListener('click', onSelect);
+      document.getElementById('btn-plan-selector-cancel')?.removeEventListener('click', onCancel);
+    };
+
+    list.addEventListener('click', onSelect);
+    document.getElementById('btn-plan-selector-cancel')?.addEventListener('click', onCancel);
+    overlay.style.display = 'flex';
+  }
+
+  /** 编辑已有模板：打开向导预填数据，保存时更新而非新建 */
+  private editTemplate(id: string): void {
+    if (this.templateModel.isBuiltin(id)) return;
+    const tpl = this.templateModel.get(id);
+    if (!tpl) return;
+    this.editingTemplateId = id;
+    this.showWizardWithTemplate(tpl as any);
+    document.getElementById('wizard-title')!.textContent = '编辑模板';
   }
 
   private async deleteTemplate(id: string): Promise<void> {
+    if (this.templateModel.isBuiltin(id)) return;
     const tpl = this.templateModel.get(id);
     if (!tpl) return;
     const ok = await this.showConfirm('确认删除', `确定删除模板「${tpl.name}」？`);
@@ -2782,6 +3198,7 @@ export class AppController {
   }
 
   private async renameTemplate(id: string): Promise<void> {
+    if (this.templateModel.isBuiltin(id)) return;
     const tpl = this.templateModel.get(id);
     if (!tpl) return;
     const newName = await this.showPrompt('重命名模板', '请输入新名称：', tpl.name);
@@ -2836,19 +3253,27 @@ export class AppController {
       return;
     }
 
-    container.innerHTML = templates.map(tpl => `
-      <div class="tpl-item" data-tpl-id="${tpl.id}">
-        <div class="tpl-item-info">
-          <div class="tpl-item-name" title="${tpl.name}">${tpl.name}</div>
-          <div class="tpl-item-type">${AppController.TEMPLATE_TYPE_LABELS[tpl.type] ?? tpl.type}${tpl.defaultTimes ? ` · ×${tpl.defaultTimes}` : ''}</div>
+    container.innerHTML = templates.map(tpl => {
+      const isBuiltin = !!tpl.builtin;
+      const builtinBadge = isBuiltin ? '<span class="tpl-builtin-badge">内置</span>' : '';
+      const planCount = tpl.planPaths?.length ?? (tpl.planPath ? 1 : 0);
+      const planInfo = tpl.type === 'normal_fight' && planCount > 1 ? ` · ${planCount}个方案` : '';
+      const descTitle = tpl.description ? ` title="${tpl.description}"` : ` title="${tpl.name}"`;
+      const editBtns = isBuiltin ? '' : `<button class="btn btn-small" data-tpl-action="edit" data-tpl-id="${tpl.id}" title="编辑">✎</button>
+         <button class="btn btn-small btn-danger" data-tpl-action="delete" data-tpl-id="${tpl.id}" title="删除">✕</button>`;
+      return `<div class="tpl-item" data-tpl-id="${tpl.id}">
+        <div class="tpl-item-info"${descTitle}>
+          <div class="tpl-item-name">${tpl.name}${builtinBadge}</div>
+          <div class="tpl-item-type">${AppController.TEMPLATE_TYPE_LABELS[tpl.type] ?? tpl.type}${planInfo}${tpl.defaultTimes ? ` · ×${tpl.defaultTimes}` : ''}</div>
         </div>
         <div class="tpl-item-actions">
-          <button class="btn btn-small btn-primary" data-tpl-action="use" data-tpl-id="${tpl.id}" title="加入队列">使用</button>
-          <button class="btn btn-small" data-tpl-action="rename" data-tpl-id="${tpl.id}" title="重命名">✎</button>
-          <button class="btn btn-small btn-danger" data-tpl-action="delete" data-tpl-id="${tpl.id}" title="删除">✕</button>
+          <button class="btn btn-small btn-primary" data-tpl-action="use" data-tpl-id="${tpl.id}" title="加入任务列表">加入列表</button>
+          ${editBtns}
         </div>
-      </div>
-    `).join('');
+      </div>`;
+    }).join('');
+
+    this.populateDecisiveTemplateSelect();
   }
 
   // ════════════════════════════════════════

--- a/src/model/ApiClient.ts
+++ b/src/model/ApiClient.ts
@@ -364,6 +364,11 @@ export class ApiClient {
     return this.request('POST', '/api/repair/bath');
   }
 
+  /** 单船泡澡修理（后端接受舰船名称，自动导航到浴室并修理） */
+  async repairShip(shipName: string): Promise<ApiResponse> {
+    return this.request('POST', '/api/repair/ship', { ship_name: shipName });
+  }
+
   async destroy(shipTypes?: string[], removeEquipment = true): Promise<ApiResponse> {
     return this.request('POST', '/api/destroy', { ship_types: shipTypes ?? null, remove_equipment: removeEquipment });
   }

--- a/src/model/ConfigModel.ts
+++ b/src/model/ConfigModel.ts
@@ -23,6 +23,8 @@ const DEFAULT_SETTINGS: UserSettings = {
     exercise_fleet_id: 1,
     auto_normal_fight: false,
     auto_decisive: false,
+    decisive_ticket_reserve: 0,
+    decisive_template_id: '',
   },
 };
 

--- a/src/model/CronScheduler.ts
+++ b/src/model/CronScheduler.ts
@@ -28,6 +28,8 @@ export interface CronConfig {
   battleType: string;
   /** 战役次数 */
   battleTimes: number;
+  /** 启用自动常规出击（每日执行任务列表） */
+  autoNormalFight: boolean;
 }
 
 /** 定时任务触发时的回调 */
@@ -36,6 +38,8 @@ export interface CronCallbacks {
   onExerciseDue?: (fleetId: number) => void;
   /** 请求添加战役任务 */
   onCampaignDue?: (campaignName: string, times: number) => void;
+  /** 请求执行任务列表中所有任务 */
+  onNormalFightDue?: () => void;
   /** 请求添加定时方案任务 */
   onScheduledTaskDue?: (taskKey: string) => void;
   /** 日志 */
@@ -58,6 +62,7 @@ const EXERCISE_REFRESH_HOURS = [0, 12, 18];
 /** localStorage key — 记录任务实际完成时间 */
 const LS_KEY_LAST_EXERCISE_RUN = 'cron_lastExerciseRun';   // ISO 时间戳
 const LS_KEY_LAST_BATTLE_RUN   = 'cron_lastBattleRun';     // YYYY-MM-DD
+const LS_KEY_LAST_NORMAL_FIGHT_RUN = 'cron_lastNormalFightRun'; // YYYY-MM-DD
 
 // ════════════════════════════════════════
 // CronScheduler 实现
@@ -72,9 +77,12 @@ export class CronScheduler {
   private lastExerciseRun: Date | null = null;
   /** 上一次战役任务实际完成的日期 (YYYY-MM-DD) */
   private lastBattleRun = '';
-  /** 是否有演习/战役任务正在排队或执行中 (避免同一会话重复入队) */
+  /** 是否有演习/战役/常规出击任务正在排队或执行中 (避免同一会话重复入队) */
   private exercisePending = false;
   private battlePending = false;
+  /** 上一次常规出击实际完成的日期 (YYYY-MM-DD) */
+  private lastNormalFightRun = '';
+  private normalFightPending = false;
   /** 注册的定时方案任务 */
   private scheduledTasks: ScheduledTask[] = [];
 
@@ -95,7 +103,7 @@ export class CronScheduler {
   start(): void {
     this.stop();
     this.loadTimestamps();
-    this.log('info', `定时调度配置: 演习=${this.config.autoExercise}, 战役=${this.config.autoBattle}`);
+    this.log('info', `定时调度配置: 演习=${this.config.autoExercise}, 战役=${this.config.autoBattle}, 常规出击=${this.config.autoNormalFight}`);
     if (this.lastExerciseRun) {
       this.log('info', `上次演习完成: ${this.lastExerciseRun.toLocaleString()}`);
     }
@@ -163,6 +171,30 @@ export class CronScheduler {
     this.battlePending = false;
   }
 
+  /** Controller 在常规出击任务全部完成后调用 */
+  markNormalFightCompleted(): void {
+    this.lastNormalFightRun = this.dateKey(new Date());
+    this.normalFightPending = false;
+    try {
+      localStorage.setItem(LS_KEY_LAST_NORMAL_FIGHT_RUN, this.lastNormalFightRun);
+    } catch { /* ignore */ }
+    this.log('info', '自动常规出击完成，已记录运行时间');
+  }
+
+  /** 常规出击任务已处理（成功或失败），今日不再重复 */
+  markNormalFightHandled(): void {
+    this.lastNormalFightRun = this.dateKey(new Date());
+    this.normalFightPending = false;
+    try {
+      localStorage.setItem(LS_KEY_LAST_NORMAL_FIGHT_RUN, this.lastNormalFightRun);
+    } catch { /* ignore */ }
+  }
+
+  /** 常规出击失败 — 清除 pending，下次 tick 重试 */
+  clearNormalFightPending(): void {
+    this.normalFightPending = false;
+  }
+
   // ── 持久化 ──
 
   /** 从 localStorage 加载上次运行时间戳 */
@@ -174,6 +206,7 @@ export class CronScheduler {
         if (!isNaN(d.getTime())) this.lastExerciseRun = d;
       }
       this.lastBattleRun = localStorage.getItem(LS_KEY_LAST_BATTLE_RUN) || '';
+      this.lastNormalFightRun = localStorage.getItem(LS_KEY_LAST_NORMAL_FIGHT_RUN) || '';
     } catch { /* ignore */ }
   }
 
@@ -209,6 +242,7 @@ export class CronScheduler {
     const now = new Date();
     this.checkExercise(now);
     this.checkCampaign(now);
+    this.checkNormalFight(now);
     this.checkScheduledTasks(now);
     this.resetDailyFlags(now);
   }
@@ -258,6 +292,22 @@ export class CronScheduler {
     this.battlePending = true;
     this.log('info', `自动战役触发 (${this.config.battleType} ×${this.config.battleTimes})`);
     this.callbacks.onCampaignDue?.(this.config.battleType, this.config.battleTimes);
+  }
+
+  /**
+   * 检查常规出击:
+   * 每日 0 点刷新。若 lastNormalFightRun 不是今天则触发，将任务列表全部加入队列。
+   */
+  private checkNormalFight(now: Date): void {
+    if (!this.config.autoNormalFight) return;
+    if (this.normalFightPending) return;
+
+    const todayStr = this.dateKey(now);
+    if (this.lastNormalFightRun >= todayStr) return;
+
+    this.normalFightPending = true;
+    this.log('info', '自动常规出击触发 (执行任务列表中所有任务)');
+    this.callbacks.onNormalFightDue?.();
   }
 
   /** 检查定时方案任务 */

--- a/src/model/RepairManager.ts
+++ b/src/model/RepairManager.ts
@@ -1,0 +1,223 @@
+/**
+ * RepairManager —— 泡澡修理管理器
+ *
+ * 功能:
+ *   - 在任务执行前检查编队舰船血量（按舰船名匹配阈值）
+ *   - 将需要修理的舰船送入泡澡，追踪修理状态
+ *   - 支持编队预设轮换：一套舰船在修时切换到另一套继续战斗
+ *
+ * 设计要点:
+ *   - 修理阈值按舰船名设定（而非舰位），适配编队重组
+ *   - 泡澡修理无需快修工具，靠等待完成
+ *   - 被延迟的任务不消耗 remainingTimes
+ */
+
+import type { ApiClient, ShipData } from './ApiClient';
+import type { BathRepairConfig, RepairThreshold } from './types';
+import { Logger } from '../utils/Logger';
+import { toBackendName } from '../data/shipData';
+
+/** 正在泡澡的舰船记录 */
+export interface BathingShip {
+  /** 舰船名称 */
+  name: string;
+  /** 送入泡澡的时间 */
+  startTime: number;
+  /** 是否已发送修理请求到后端 */
+  requestSent: boolean;
+}
+
+/** 修理检查结果 */
+export interface RepairCheckResult {
+  /** 是否可以执行任务（无船需要修理） */
+  ready: boolean;
+  /** 需要修理的舰船名称列表 */
+  shipsNeedRepair: string[];
+  /** 已在泡澡中的舰船 */
+  shipsInBath: string[];
+}
+
+export class RepairManager {
+  private api: ApiClient;
+  /** 正在泡澡的舰船列表 (舰船名 → 记录) */
+  private bathingShips: Map<string, BathingShip> = new Map();
+
+  constructor(api: ApiClient) {
+    this.api = api;
+  }
+
+  /** 获取舰船的修理阈值（优先按名查找，回退到默认阈值） */
+  private getThreshold(shipName: string, config: BathRepairConfig): RepairThreshold {
+    if (config.shipThresholds) {
+      // 直接匹配
+      if (config.shipThresholds[shipName]) return config.shipThresholds[shipName];
+      // UI 端用显示名（含 ·改），后端用基础名，需交叉匹配
+      const normalized = toBackendName(shipName);
+      for (const [key, value] of Object.entries(config.shipThresholds)) {
+        if (toBackendName(key) === normalized) return value;
+      }
+    }
+    return config.defaultThreshold;
+  }
+
+  /**
+   * 检查指定编队的舰船是否需要修理（按舰船名匹配阈值）
+   * @param fleetId 编队号 (1-4)
+   * @param config 泡澡修理配置
+   * @returns 检查结果
+   */
+  async checkFleetHealth(fleetId: number, config: BathRepairConfig): Promise<RepairCheckResult> {
+    if (!config.enabled) {
+      return { ready: true, shipsNeedRepair: [], shipsInBath: [] };
+    }
+
+    try {
+      const resp = await this.api.gameContext();
+      if (!resp.success || !resp.data?.fleets) {
+        Logger.warn('无法获取编队信息，跳过修理检查', 'repair');
+        return { ready: true, shipsNeedRepair: [], shipsInBath: [] };
+      }
+
+      const fleet = resp.data.fleets.find(f => f.fleet_id === fleetId);
+      if (!fleet) {
+        Logger.warn(`编队 ${fleetId} 不存在`, 'repair');
+        return { ready: true, shipsNeedRepair: [], shipsInBath: [] };
+      }
+
+      const shipsNeedRepair: string[] = [];
+      const shipsInBath: string[] = [];
+
+      for (const ship of fleet.ships) {
+        if (!ship || !ship.name) continue;
+
+        const normalized = toBackendName(ship.name);
+        const threshold = this.getThreshold(ship.name, config);
+        if (this.needsRepair(ship, threshold)) {
+          if (this.bathingShips.has(normalized)) {
+            shipsInBath.push(ship.name);
+          } else {
+            shipsNeedRepair.push(ship.name);
+          }
+        } else {
+          // 舰船已修好，清除泡澡记录
+          if (this.bathingShips.has(normalized)) {
+            Logger.info(`舰船「${ship.name}」已修复，移除泡澡记录`, 'repair');
+            this.bathingShips.delete(normalized);
+          }
+        }
+      }
+
+      const ready = shipsNeedRepair.length === 0 && shipsInBath.length === 0;
+      return { ready, shipsNeedRepair, shipsInBath };
+    } catch (e) {
+      Logger.error(`修理检查失败: ${e}`, 'repair');
+      return { ready: true, shipsNeedRepair: [], shipsInBath: [] };
+    }
+  }
+
+  /** 判断单船是否需要修理 */
+  private needsRepair(ship: ShipData, threshold: RepairThreshold): boolean {
+    if (ship.max_health <= 0) return false;
+    const hpRatio = ship.health / ship.max_health;
+
+    if (threshold.type === 'percent') {
+      return hpRatio <= threshold.value / 100;
+    } else {
+      return ship.health <= threshold.value;
+    }
+  }
+
+  /**
+   * 将舰船送入泡澡
+   */
+  async sendToBath(shipNames: string[]): Promise<void> {
+    for (const name of shipNames) {
+      const key = toBackendName(name);
+      if (this.bathingShips.has(key)) continue;
+      this.bathingShips.set(key, {
+        name,
+        startTime: Date.now(),
+        requestSent: false,
+      });
+
+      try {
+        await this.api.repairShip(name);
+        const entry = this.bathingShips.get(key);
+        if (entry) entry.requestSent = true;
+        Logger.info(`舰船「${name}」已送入泡澡修理`, 'repair');
+      } catch (e) {
+        Logger.error(`舰船「${name}」送入泡澡失败: ${e}`, 'repair');
+        this.bathingShips.delete(key);
+      }
+    }
+  }
+
+  /**
+   * 刷新泡澡状态: 通过 gameContext 检查舰船血量，移除已修好的记录
+   */
+  async refreshBathingStatus(fleetId: number, config: BathRepairConfig): Promise<void> {
+    if (this.bathingShips.size === 0) return;
+
+    try {
+      const resp = await this.api.gameContext();
+      if (!resp.success || !resp.data?.fleets) return;
+
+      // 收集所有编队中的舰船数据
+      const allShips = new Map<string, ShipData>();
+      for (const fleet of resp.data.fleets) {
+        for (const ship of fleet.ships) {
+          if (ship?.name) allShips.set(ship.name, ship);
+        }
+      }
+
+      // 检查泡澡中的舰船是否已修理完成
+      for (const [name] of this.bathingShips) {
+        const ship = allShips.get(name);
+        if (!ship) {
+          // 舰船不在任何编队（可能被卸下），保留记录等下次检查
+          continue;
+        }
+        const threshold = this.getThreshold(name, config);
+        if (!this.needsRepair(ship, threshold)) {
+          Logger.info(`舰船「${name}」泡澡修理完成`, 'repair');
+          this.bathingShips.delete(name);
+        }
+      }
+    } catch (e) {
+      Logger.debug(`刷新泡澡状态失败: ${e}`, 'repair');
+    }
+  }
+
+  /**
+   * 从编队预设列表中找到一个所有舰船都不在泡澡中的预设
+   * @param presets 编队预设列表 (name + ships[])
+   * @param skipIndex 跳过的预设索引（当前正在使用的）
+   * @returns 可用预设的索引，或 -1（全部有船在泡澡）
+   */
+  findHealthyPreset(presets: Array<{ name: string; ships: string[] }>, skipIndex: number): number {
+    for (let i = 0; i < presets.length; i++) {
+      if (i === skipIndex) continue;
+      const preset = presets[i];
+      const hasShipInBath = preset.ships.some(name => this.bathingShips.has(toBackendName(name)));
+      if (!hasShipInBath) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  /** 是否有舰船正在泡澡 */
+  get hasBathingShips(): boolean {
+    return this.bathingShips.size > 0;
+  }
+
+  /** 获取正在泡澡的舰船列表 */
+  get bathingShipNames(): string[] {
+    return Array.from(this.bathingShips.keys());
+  }
+
+  /** 清除所有泡澡记录 */
+  clearAll(): void {
+    this.bathingShips.clear();
+  }
+}

--- a/src/model/Scheduler.ts
+++ b/src/model/Scheduler.ts
@@ -20,8 +20,9 @@ import {
   type WsTaskCompleted,
   type TaskResult,
 } from './ApiClient';
-import type { StopCondition } from './types';
+import type { StopCondition, BathRepairConfig, FleetPreset } from './types';
 import { Logger } from '../utils/Logger';
+import { RepairManager } from './RepairManager';
 
 // ════════════════════════════════════════
 // 任务队列项
@@ -60,6 +61,14 @@ export interface SchedulerTask {
   maxRetries: number;
   /** 当前已重试次数 */
   retryCount: number;
+  /** 泡澡修理配置 (可选) */
+  bathRepairConfig?: BathRepairConfig;
+  /** 任务使用的编队号 (用于泡澡修理前检查编队状态) */
+  fleetId?: number;
+  /** 可用的编队预设列表 (用于泡澡修理时轮换舰船) */
+  fleetPresets?: FleetPreset[];
+  /** 当前使用的编队预设索引 (-1 = 未使用预设) */
+  currentPresetIndex?: number;
 }
 
 // ════════════════════════════════════════
@@ -131,8 +140,16 @@ export class Scheduler {
   private lastExpeditionCheck = 0; // timestamp ms
   private expeditionIntervalMs = DEFAULT_EXPEDITION_INTERVAL_MS;
 
+  // ── 泡澡修理 ──
+  private repairManager: RepairManager;
+  /** 因舰船修理被延迟的任务列表 */
+  private deferredTasks: SchedulerTask[] = [];
+  /** 延迟任务重试定时器 */
+  private deferredRetryTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(api: ApiClient) {
     this.api = api;
+    this.repairManager = new RepairManager(api);
     this.setupApiCallbacks();
   }
 
@@ -228,6 +245,10 @@ export class Scheduler {
     priority: TaskPriority = TaskPriority.USER_TASK,
     times: number = 1,
     stopCondition?: StopCondition,
+    bathRepairConfig?: BathRepairConfig,
+    fleetId?: number,
+    fleetPresets?: FleetPreset[],
+    currentPresetIndex?: number,
   ): string {
     const id = generateTaskId();
     const task: SchedulerTask = {
@@ -241,6 +262,10 @@ export class Scheduler {
       stopCondition,
       maxRetries: 2,
       retryCount: 0,
+      bathRepairConfig,
+      fleetId,
+      fleetPresets,
+      currentPresetIndex: currentPresetIndex ?? -1,
     };
 
     // 按优先级插入队列
@@ -283,6 +308,11 @@ export class Scheduler {
       try { await this.api.taskStop(); } catch { /* ignore */ }
       this.currentTask = null;
     }
+    // 清理延迟任务
+    if (this.deferredRetryTimer) {
+      clearTimeout(this.deferredRetryTimer);
+      this.deferredRetryTimer = null;
+    }
     this.setStatus('idle');
     this.notifyQueueChange();
   }
@@ -309,6 +339,12 @@ export class Scheduler {
   /** 清空队列 (不影响当前正在运行的) */
   clearQueue(): void {
     this.queue = [];
+    this.deferredTasks = [];
+    if (this.deferredRetryTimer) {
+      clearTimeout(this.deferredRetryTimer);
+      this.deferredRetryTimer = null;
+    }
+    this.repairManager.clearAll();
     this.notifyQueueChange();
   }
 
@@ -327,7 +363,12 @@ export class Scheduler {
   private async consumeNext(): Promise<void> {
     if (this.currentTask) return; // 还有任务在跑
     if (this.queue.length === 0) {
-      this.setStatus('idle');
+      // 如果有延迟任务，定时重试
+      if (this.deferredTasks.length > 0) {
+        this.scheduleDeferredRetry();
+      } else {
+        this.setStatus('idle');
+      }
       return;
     }
 
@@ -362,6 +403,44 @@ export class Scheduler {
         this.currentTask = null;
         this.consumeNext();
         return;
+      }
+    }
+
+    // 泡澡修理检查: 如果舰船需要修理，尝试编队预设轮换或延迟任务
+    if (task.bathRepairConfig?.enabled && task.fleetId) {
+      const checkResult = await this.repairManager.checkFleetHealth(task.fleetId, task.bathRepairConfig);
+      if (!checkResult.ready) {
+        // 当前编队有舰船需要修理 → 送入泡澡
+        if (checkResult.shipsNeedRepair.length > 0) {
+          this.emitLog('info', `任务「${task.name}」: ${checkResult.shipsNeedRepair.join('、')} 需要修理，送入泡澡`);
+          await this.repairManager.sendToBath(checkResult.shipsNeedRepair);
+        }
+
+        // 尝试编队预设轮换: 切换到一套没有舰船在泡澡的预设
+        const presets = task.fleetPresets;
+        if (presets && presets.length > 1) {
+          const healthyIdx = this.repairManager.findHealthyPreset(presets, task.currentPresetIndex ?? -1);
+          if (healthyIdx >= 0) {
+            const preset = presets[healthyIdx];
+            this.emitLog('info', `任务「${task.name}」: 轮换至编队预设「${preset.name}」`);
+            this.switchTaskPreset(task, healthyIdx);
+            // 继续往下执行 taskStart
+          } else {
+            // 所有预设都有舰船在泡澡 → 延迟
+            this.emitLog('info', `任务「${task.name}」: 所有编队预设的舰船都在修理中，任务延迟`);
+            this.deferTask(task);
+            return;
+          }
+        } else {
+          // 未配置预设轮换 → 延迟
+          if (checkResult.shipsInBath.length > 0) {
+            this.emitLog('info', `任务「${task.name}」: ${checkResult.shipsInBath.join('、')} 正在泡澡中，任务延迟`);
+          } else {
+            this.emitLog('info', `任务「${task.name}」: 舰船正在修理，任务延迟`);
+          }
+          this.deferTask(task);
+          return;
+        }
       }
     }
 
@@ -464,6 +543,10 @@ export class Scheduler {
         stopCondition: finished.stopCondition,
         maxRetries: finished.maxRetries,
         retryCount: 0,
+        bathRepairConfig: finished.bathRepairConfig,
+        fleetId: finished.fleetId,
+        fleetPresets: finished.fleetPresets,
+        currentPresetIndex: finished.currentPresetIndex,
       };
       Logger.debug(`followUp: 「${finished.name}」 remaining=${followUp.remainingTimes}/${followUp.totalTimes}`, 'scheduler');
       this.insertByPriority(followUp);
@@ -572,6 +655,67 @@ export class Scheduler {
     } else {
       this.queue.splice(idx, 0, task);
     }
+  }
+
+  // ── 泡澡修理: 延迟任务管理 ──
+
+  /** 将任务放入延迟列表，不消耗 remainingTimes */
+  private deferTask(task: SchedulerTask): void {
+    this.currentTask = null;
+    this.deferredTasks.push(task);
+    this.notifyQueueChange();
+    // 尝试执行队列中其他任务
+    if (this.queue.length > 0) {
+      this.consumeNext();
+    } else {
+      this.scheduleDeferredRetry();
+    }
+  }
+
+  /** 切换任务使用的编队预设（修改 request 中的 fleet 舰船列表） */
+  private switchTaskPreset(task: SchedulerTask, presetIndex: number): void {
+    const preset = task.fleetPresets?.[presetIndex];
+    if (!preset) return;
+    task.currentPresetIndex = presetIndex;
+
+    const req = task.request;
+    if (req.type === 'normal_fight' || req.type === 'event_fight') {
+      const fleet = preset.ships.map(n => n.endsWith('·改') ? n.slice(0, -2) : n);
+      if (req.plan) {
+        req.plan.fleet = fleet;
+      } else {
+        (req as any).plan = { fleet, fleet_id: task.fleetId };
+      }
+    }
+  }
+
+  /** 30 秒后重新尝试延迟任务 */
+  private scheduleDeferredRetry(): void {
+    if (this.deferredRetryTimer) return;
+    this.emitLog('info', '所有任务因修理被阻塞，30 秒后重试...');
+    this.setStatus('idle');
+    this.deferredRetryTimer = setTimeout(() => {
+      this.deferredRetryTimer = null;
+      this.retryDeferredTasks();
+    }, 30_000);
+  }
+
+  /** 重新尝试延迟的任务 */
+  private retryDeferredTasks(): void {
+    if (this.deferredTasks.length === 0) return;
+    // 将所有延迟任务按优先级插回队列
+    for (const task of this.deferredTasks) {
+      this.insertByPriority(task);
+    }
+    this.deferredTasks = [];
+    this.notifyQueueChange();
+    this.emitLog('info', '延迟任务已重新加入队列，尝试执行');
+    this.consumeNext();
+  }
+
+  /** 获取延迟任务列表（只读） */
+  get deferredTaskList(): ReadonlyArray<SchedulerTask> {
+    return this.deferredTasks;
   }
 
   // ── 内部: 远征定时器 ──

--- a/src/model/TaskGroupModel.ts
+++ b/src/model/TaskGroupModel.ts
@@ -10,14 +10,22 @@ import { Logger } from '../utils/Logger';
 
 /** 任务组中的单个条目 */
 export interface TaskGroupItem {
-  /** 文件路径 (相对于 appRoot 或绝对路径) */
-  path: string;
-  /** 条目类型: plan=战斗方案, preset=任务预设 */
-  kind: 'plan' | 'preset';
+  /** 文件路径 (战斗方案/预设 YAML) — plan/preset 类型必填 */
+  path?: string;
+  /** 模板 ID — template 类型必填 */
+  templateId?: string;
+  /** 条目类型: plan=战斗方案YAML, preset=任务预设YAML, template=模板库引用 */
+  kind: 'plan' | 'preset' | 'template';
   /** 执行次数 */
   times: number;
-  /** 显示名称 (从文件名派生) */
+  /** 显示名称 */
   label: string;
+  /** 战役类型覆盖（仅 campaign 模板使用时选择） */
+  campaignName?: string;
+  /** 舰队编号覆盖（仅 exercise 模板使用时选择） */
+  fleet_id?: number;
+  /** 章节覆盖（仅 decisive 模板使用时选择） */
+  chapter?: number;
 }
 
 /** 一个任务组 */

--- a/src/model/TemplateModel.ts
+++ b/src/model/TemplateModel.ts
@@ -1,6 +1,7 @@
 import type { TaskTemplate } from './types';
 
 const FILE_PATH = 'templates/templates.json';
+const BUILTIN_PATH = 'resource/builtin_templates.json';
 
 let idCounter = 0;
 function generateId(): string {
@@ -14,23 +15,31 @@ interface FileIO {
 }
 
 export class TemplateModel {
-  private templates: TaskTemplate[] = [];
+  private builtinTemplates: TaskTemplate[] = [];
+  private userTemplates: TaskTemplate[] = [];
   private io: FileIO | null = null;
 
   /** 初始化：传入 IPC bridge 并从本地文件加载 */
   async init(io: FileIO): Promise<void> {
     this.io = io;
+    await this.loadBuiltin();
     await this.load();
   }
 
-  /** 所有模板 */
+  /** 所有模板（内置 + 用户） */
   getAll(): readonly TaskTemplate[] {
-    return this.templates;
+    return [...this.builtinTemplates, ...this.userTemplates];
   }
 
   /** 查找模板 */
   get(id: string): TaskTemplate | undefined {
-    return this.templates.find(t => t.id === id);
+    return this.builtinTemplates.find(t => t.id === id)
+      ?? this.userTemplates.find(t => t.id === id);
+  }
+
+  /** 是否为内置模板 */
+  isBuiltin(id: string): boolean {
+    return this.builtinTemplates.some(t => t.id === id);
   }
 
   /** 添加模板 */
@@ -40,25 +49,37 @@ export class TemplateModel {
       id: generateId(),
       createdAt: new Date().toISOString(),
     };
-    this.templates.push(full);
+    this.userTemplates.push(full);
     await this.save();
     return full;
   }
 
-  /** 删除模板 */
+  /** 删除模板（内置模板不可删除） */
   async remove(id: string): Promise<boolean> {
-    const idx = this.templates.findIndex(t => t.id === id);
+    if (this.isBuiltin(id)) return false;
+    const idx = this.userTemplates.findIndex(t => t.id === id);
     if (idx < 0) return false;
-    this.templates.splice(idx, 1);
+    this.userTemplates.splice(idx, 1);
     await this.save();
     return true;
   }
 
-  /** 重命名模板 */
+  /** 重命名模板（内置模板不可重命名） */
   async rename(id: string, newName: string): Promise<void> {
-    const tpl = this.get(id);
+    if (this.isBuiltin(id)) return;
+    const tpl = this.userTemplates.find(t => t.id === id);
     if (tpl) {
-      (tpl as TaskTemplate).name = newName;
+      tpl.name = newName;
+      await this.save();
+    }
+  }
+
+  /** 更新模板字段（内置模板不可更新） */
+  async update(id: string, fields: Partial<Omit<TaskTemplate, 'id' | 'createdAt' | 'builtin'>>): Promise<void> {
+    if (this.isBuiltin(id)) return;
+    const tpl = this.userTemplates.find(t => t.id === id);
+    if (tpl) {
+      Object.assign(tpl, fields);
       await this.save();
     }
   }
@@ -75,26 +96,28 @@ export class TemplateModel {
         id: generateId(),
         createdAt: new Date().toISOString(),
       };
-      this.templates.push(tpl);
+      // 导入的模板始终为用户模板
+      delete (tpl as any).builtin;
+      this.userTemplates.push(tpl);
       count++;
     }
     if (count > 0) await this.save();
     return count;
   }
 
-  /** 持久化到本地文件 templates.json */
+  /** 持久化用户模板到本地文件 */
   private async save(): Promise<void> {
     if (!this.io) return;
-    await this.io.saveFile(FILE_PATH, JSON.stringify(this.templates, null, 2));
+    await this.io.saveFile(FILE_PATH, JSON.stringify(this.userTemplates, null, 2));
   }
 
-  /** 从本地文件加载 */
+  /** 从本地文件加载用户模板 */
   private async load(): Promise<void> {
     if (!this.io) return;
     try {
       const raw = await this.io.readFile(FILE_PATH);
       if (raw) {
-        this.templates = JSON.parse(raw);
+        this.userTemplates = JSON.parse(raw);
         return;
       }
     } catch { /* 文件不存在 */ }
@@ -102,9 +125,22 @@ export class TemplateModel {
     try {
       const raw = await this.io.readFile('templates.json');
       if (raw) {
-        this.templates = JSON.parse(raw);
+        this.userTemplates = JSON.parse(raw);
         await this.save(); // 保存到新路径
       }
     } catch { /* 旧文件也不存在，使用空列表 */ }
+  }
+
+  /** 从只读资源加载内置模板 */
+  private async loadBuiltin(): Promise<void> {
+    if (!this.io) return;
+    try {
+      const raw = await this.io.readFile(BUILTIN_PATH);
+      if (raw) {
+        const arr = JSON.parse(raw) as TaskTemplate[];
+        // 确保内置标记
+        this.builtinTemplates = arr.map(t => ({ ...t, builtin: true }));
+      }
+    } catch { /* 内置模板文件不存在 */ }
   }
 }

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -74,6 +74,8 @@ export interface DailyAutomation {
   exercise_fleet_id: number;
   auto_normal_fight: boolean;
   auto_decisive: boolean;
+  decisive_ticket_reserve: number;
+  decisive_template_id: string;
 }
 
 export interface UserSettings {
@@ -158,8 +160,14 @@ export interface TaskTemplate {
   type: TemplateType;
   createdAt: string;
 
+  /** 是否为内置模板（只读，不可删除/编辑） */
+  builtin?: boolean;
+  /** 内置模板的描述说明 */
+  description?: string;
+
   // normal_fight / event_fight
-  planPath?: string;               // 引用的方案文件路径
+  planPath?: string;               // 引用的方案文件路径（单方案，向后兼容）
+  planPaths?: string[];            // 可选方案列表（多方案模板）
   fleet_id?: number;
   fleet?: string[];                // 编队舰船名称 (6 个位置)
 
@@ -179,4 +187,26 @@ export interface TaskTemplate {
   defaultTimes?: number;
   defaultGap?: number;
   defaultStopCondition?: StopCondition;
+}
+
+// ════════════════════════════════════════
+// 泡澡修理配置 (Bath Repair)
+// ════════════════════════════════════════
+
+/** 单船修理阈值: 血量低于阈值时送入泡澡 */
+export interface RepairThreshold {
+  /** 阈值类型: percent=百分比 (如0.25=25%), absolute=绝对值 (如13点HP) */
+  type: 'percent' | 'absolute';
+  /** 阈值数值 */
+  value: number;
+}
+
+/** 任务级泡澡修理配置 */
+export interface BathRepairConfig {
+  /** 是否启用泡澡修理（启用后不使用快修，等待泡澡完成） */
+  enabled: boolean;
+  /** 默认修理阈值（适用于所有舰船） */
+  defaultThreshold: RepairThreshold;
+  /** 按舰船名覆盖修理阈值 (显示名 → 阈值) */
+  shipThresholds?: Record<string, RepairThreshold>;
 }

--- a/src/view/ConfigView.ts
+++ b/src/view/ConfigView.ts
@@ -18,6 +18,8 @@ export class ConfigView {
   private battleTimes: HTMLInputElement;
   private autoNormalFight: HTMLInputElement;
   private autoDecisive: HTMLInputElement;
+  private decisiveTicketReserve: HTMLInputElement;
+  private decisiveTemplate: HTMLSelectElement;
   private themeMode: HTMLSelectElement;
   private accentColor: HTMLInputElement;
   private accentLabel: HTMLElement;
@@ -37,6 +39,8 @@ export class ConfigView {
     this.battleTimes = document.getElementById('cfg-battle-times') as HTMLInputElement;
     this.autoNormalFight = document.getElementById('cfg-auto-normal-fight') as HTMLInputElement;
     this.autoDecisive = document.getElementById('cfg-auto-decisive') as HTMLInputElement;
+    this.decisiveTicketReserve = document.getElementById('cfg-decisive-ticket-reserve') as HTMLInputElement;
+    this.decisiveTemplate = document.getElementById('cfg-decisive-template') as HTMLSelectElement;
     this.themeMode = document.getElementById('cfg-theme-mode') as HTMLSelectElement;
     this.accentColor = document.getElementById('cfg-accent-color') as HTMLInputElement;
     this.accentLabel = document.getElementById('cfg-accent-label')!;
@@ -63,6 +67,9 @@ export class ConfigView {
     this.battleTimes.value = String(vo.battleTimes);
     this.autoNormalFight.checked = vo.autoNormalFight;
     this.autoDecisive.checked = vo.autoDecisive;
+    this.decisiveTicketReserve.value = String(vo.decisiveTicketReserve);
+    // 决战模板下拉列表由 Controller 填充 options
+    this.decisiveTemplate.value = vo.decisiveTemplateId;
     this.themeMode.value = vo.themeMode;
     this.accentColor.value = vo.accentColor;
     this.accentLabel.textContent = vo.accentColor;
@@ -85,6 +92,8 @@ export class ConfigView {
       battleTimes: Number(this.battleTimes.value) || 3,
       autoNormalFight: this.autoNormalFight.checked,
       autoDecisive: this.autoDecisive.checked,
+      decisiveTicketReserve: Math.max(0, Number(this.decisiveTicketReserve.value) || 0),
+      decisiveTemplateId: this.decisiveTemplate.value,
       themeMode: this.themeMode.value as 'dark' | 'light' | 'system',
       accentColor: this.accentColor.value,
       debugMode: this.debugMode.checked,

--- a/src/view/PlanPreviewView.ts
+++ b/src/view/PlanPreviewView.ts
@@ -4,6 +4,7 @@
  */
 import type { PlanPreviewViewObject, NodeViewObject, MapNodeType, MapEdgeVO, FleetPresetVO } from './viewObjects';
 import { ALL_SHIPS, shipTypeLabel } from '../data/shipData';
+import type { BathRepairConfig, RepairThreshold } from '../model/types';
 
 const FORMATION_SHORT: Record<string, string> = {
   '单纵阵': '单纵',
@@ -66,8 +67,11 @@ export class PlanPreviewView {
   private shipGeInput: HTMLInputElement;
   private taskConfigEl: HTMLElement;
 
-  /** 当前选中的编队预设索引 (-1 = 未选择) */
-  selectedFleetPresetIndex = -1;
+  /** 当前选中的编队预设索引集合 (多选) */
+  selectedFleetPresetIndices: Set<number> = new Set();
+
+  /** 当前方案的编队预设列表（用于动态渲染泡澡舰船阈值） */
+  private currentPresets: FleetPresetVO[] = [];
 
   /** 外部回调：用户点击某个节点 chip 时触发 */
   onNodeClick?: (nodeId: string) => void;
@@ -135,10 +139,124 @@ export class PlanPreviewView {
       this.onPlanFieldChange?.('ship_count_ge', v >= 0 ? v : undefined);
     });
 
+    // 泡澡修理开关
+    const bathToggle = document.getElementById('plan-bath-repair-enable') as HTMLInputElement;
+    const bathConfigDiv = document.getElementById('bath-repair-config');
+    if (bathToggle && bathConfigDiv) {
+      bathToggle.addEventListener('change', () => {
+        bathConfigDiv.style.display = bathToggle.checked ? '' : 'none';
+      });
+    }
+
     // 点击注释区域进入编辑模式
     this.commentEl.addEventListener('click', () => {
       this.startCommentEdit();
     });
+  }
+
+  /** 读取泡澡修理配置（未启用时返回 undefined） */
+  getBathRepairConfig(): BathRepairConfig | undefined {
+    const toggle = document.getElementById('plan-bath-repair-enable') as HTMLInputElement;
+    if (!toggle || !toggle.checked) return undefined;
+
+    // 默认阈值
+    const typeEl = document.getElementById('bath-default-th-type') as HTMLSelectElement;
+    const valueEl = document.getElementById('bath-default-th-value') as HTMLInputElement;
+    const type = typeEl?.value === 'absolute' ? 'absolute' as const : 'percent' as const;
+    const value = valueEl ? parseInt(valueEl.value, 10) : 50;
+
+    // 按舰船名读取覆盖阈值
+    const shipThresholds: Record<string, RepairThreshold> = {};
+    document.querySelectorAll<HTMLElement>('.bath-ship-th-row').forEach(row => {
+      const shipName = row.dataset.ship;
+      if (!shipName) return;
+      const sType = (row.querySelector('.bath-ship-th-type') as HTMLSelectElement)?.value;
+      const sValue = parseInt((row.querySelector('.bath-ship-th-value') as HTMLInputElement)?.value ?? '', 10);
+      if (!isNaN(sValue)) {
+        shipThresholds[shipName] = {
+          type: sType === 'absolute' ? 'absolute' : 'percent',
+          value: sValue,
+        };
+      }
+    });
+
+    return {
+      enabled: true,
+      defaultThreshold: { type, value: isNaN(value) ? 50 : value },
+      shipThresholds: Object.keys(shipThresholds).length > 0 ? shipThresholds : undefined,
+    };
+  }
+
+  /** 获取选中的编队预设列表 */
+  getSelectedPresets(): FleetPresetVO[] {
+    const result: FleetPresetVO[] = [];
+    const sorted = Array.from(this.selectedFleetPresetIndices).sort((a, b) => a - b);
+    for (const idx of sorted) {
+      if (idx < this.currentPresets.length) result.push(this.currentPresets[idx]);
+    }
+    return result;
+  }
+
+  /** 根据选中的编队预设，动态渲染泡澡修理的舰船阈值列表 */
+  private renderBathShipThresholds(): void {
+    const container = document.getElementById('bath-ship-thresholds');
+    if (!container) return;
+
+    // 收集选中预设的所有不重复舰船名（保持出现顺序）
+    const shipNames: string[] = [];
+    const seen = new Set<string>();
+    const sorted = Array.from(this.selectedFleetPresetIndices).sort((a, b) => a - b);
+    for (const idx of sorted) {
+      const preset = this.currentPresets[idx];
+      if (!preset) continue;
+      for (const name of preset.ships) {
+        if (!seen.has(name)) {
+          seen.add(name);
+          shipNames.push(name);
+        }
+      }
+    }
+
+    container.innerHTML = '';
+    if (shipNames.length === 0) {
+      container.style.display = 'none';
+      return;
+    }
+
+    container.style.display = '';
+
+    // 表头（用 display:contents 让子元素直接参与父 grid）
+    const header = document.createElement('div');
+    header.className = 'bath-ship-th-header-row';
+    header.innerHTML = '<span class="bath-ship-th-label-h">舰船</span><span class="bath-ship-th-h">类型</span><span class="bath-ship-th-h">阈值</span>';
+    container.appendChild(header);
+
+    for (const name of shipNames) {
+      const row = document.createElement('div');
+      row.className = 'bath-ship-th-row';
+      row.dataset.ship = name;
+
+      const label = document.createElement('span');
+      label.className = 'bath-ship-th-label';
+      label.textContent = name;
+      label.title = name;
+      row.appendChild(label);
+
+      const sel = document.createElement('select');
+      sel.className = 'input input-inline bath-ship-th-type';
+      sel.innerHTML = '<option value="percent">百分比</option><option value="absolute">绝对值</option>';
+      row.appendChild(sel);
+
+      const inp = document.createElement('input');
+      inp.type = 'number';
+      inp.className = 'input input-inline input-small bath-ship-th-value';
+      inp.value = '50';
+      inp.min = '0';
+      inp.max = '999';
+      row.appendChild(inp);
+
+      container.appendChild(row);
+    }
   }
 
   /** 进入注释编辑模式 */
@@ -428,16 +546,17 @@ export class PlanPreviewView {
   renderFleetPresets(presets?: FleetPresetVO[]): void {
     this.fleetPresetSection.style.display = '';
     this.fleetPresetListEl.innerHTML = '';
+    this.currentPresets = presets ?? [];
 
     if (!presets || presets.length === 0) {
-      this.selectedFleetPresetIndex = -1;
+      this.selectedFleetPresetIndices.clear();
+      this.renderBathShipThresholds();
       return;
     }
-    this.fleetPresetListEl.innerHTML = '';
 
     presets.forEach((preset, index) => {
       const item = document.createElement('div');
-      item.className = 'fleet-preset-item' + (index === this.selectedFleetPresetIndex ? ' selected' : '');
+      item.className = 'fleet-preset-item' + (this.selectedFleetPresetIndices.has(index) ? ' selected' : '');
 
       // 第一行：名称 + 操作按钮
       const row = document.createElement('div');
@@ -466,11 +585,14 @@ export class PlanPreviewView {
       deleteBtn.title = '删除编队';
       deleteBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        if (this.selectedFleetPresetIndex === index) {
-          this.selectedFleetPresetIndex = -1;
-        } else if (this.selectedFleetPresetIndex > index) {
-          this.selectedFleetPresetIndex--;
+        // 重新计算选中集合
+        const newSet = new Set<number>();
+        for (const idx of this.selectedFleetPresetIndices) {
+          if (idx < index) newSet.add(idx);
+          else if (idx > index) newSet.add(idx - 1);
+          // idx === index: 不加入（已删除）
         }
+        this.selectedFleetPresetIndices = newSet;
         this.onFleetPresetChange?.('delete', index);
       });
       actionsEl.appendChild(deleteBtn);
@@ -490,14 +612,15 @@ export class PlanPreviewView {
       item.appendChild(shipsEl);
 
       item.addEventListener('click', () => {
-        if (this.selectedFleetPresetIndex === index) {
-          this.selectedFleetPresetIndex = -1;
+        if (this.selectedFleetPresetIndices.has(index)) {
+          this.selectedFleetPresetIndices.delete(index);
         } else {
-          this.selectedFleetPresetIndex = index;
+          this.selectedFleetPresetIndices.add(index);
         }
         this.fleetPresetListEl.querySelectorAll('.fleet-preset-item').forEach((el, i) => {
-          el.classList.toggle('selected', i === this.selectedFleetPresetIndex);
+          el.classList.toggle('selected', this.selectedFleetPresetIndices.has(i));
         });
+        this.renderBathShipThresholds();
       });
 
       this.fleetPresetListEl.appendChild(item);

--- a/src/view/TaskGroupView.ts
+++ b/src/view/TaskGroupView.ts
@@ -114,18 +114,19 @@ export class TaskGroupView {
     const label = document.createElement('span');
     label.className = 'tg-label';
     label.textContent = item.label;
-    label.title = item.path;
+    label.title = item.path ?? item.templateId ?? '';
     row.appendChild(label);
 
     // 类型标签
     const kind = document.createElement('span');
     kind.className = 'tg-kind';
-    kind.textContent = item.kind === 'plan' ? '方案' : '预设';
+    kind.textContent = item.kind === 'plan' ? '方案' : item.kind === 'template' ? '模板' : '预设';
     row.appendChild(kind);
 
     // 详情：显示任务元数据（与名称同行）
     const detail = document.createElement('span');
     detail.className = 'tg-detail';
+    const fallback = item.path ?? item.label;
     if (meta) {
       const parts: string[] = [];
       if (meta.typeLabel) parts.push(meta.typeLabel);
@@ -135,11 +136,11 @@ export class TaskGroupView {
       if (meta.fleet && meta.fleet.length > 0) {
         parts.push(meta.fleet.filter(Boolean).join(' / '));
       }
-      detail.textContent = parts.join(' · ') || item.path;
+      detail.textContent = parts.join(' · ') || fallback;
     } else {
-      detail.textContent = item.path;
+      detail.textContent = fallback;
     }
-    detail.title = item.path;
+    detail.title = item.path ?? '';
     row.appendChild(detail);
 
     // 次数标签 + 输入

--- a/src/view/index.html
+++ b/src/view/index.html
@@ -10,7 +10,7 @@
 <body>
   <!-- ═══ 顶部导航栏 ═══ -->
   <nav class="nav-bar">
-    <div class="nav-title">WSGR GUI</div>
+    <div class="nav-title">WSGR GUI <span class="nav-version" id="app-version"></span></div>
     <div class="nav-tabs">
       <button class="nav-tab active" data-page="main">主页</button>
       <button class="nav-tab" data-page="plan">方案预览</button>
@@ -84,10 +84,10 @@
               </div>
             </div>
             <div class="task-group-items" id="task-group-items">
-              <p class="tg-empty">暂无任务条目，导入方案后点击「加入任务组」添加</p>
+              <p class="tg-empty">暂无任务。可从方案预览页的模板库「加入列表」，或点击下方「从文件添加」。</p>
             </div>
             <div class="task-group-actions">
-              <button class="btn btn-primary btn-small" id="btn-tg-load-all">全部加入队列</button>
+              <button class="btn btn-primary btn-small" id="btn-tg-load-all">全部开始执行</button>
               <button class="btn btn-small" id="btn-tg-add-file">从文件添加</button>
               <button class="btn btn-small" id="btn-tg-export" title="导出任务列表为文件">导出列表</button>
               <button class="btn btn-small" id="btn-tg-import" title="从文件导入任务列表">导入列表</button>
@@ -179,6 +179,21 @@
           <div class="modal-actions">
             <button class="btn btn-primary" id="btn-new-plan-confirm">确定</button>
             <button class="btn" id="btn-new-plan-cancel">取消</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ═══ 方案选择器弹窗（多方案模板选择具体方案） ═══ -->
+      <div id="plan-selector-dialog" class="modal-overlay" style="display:none">
+        <div class="modal card" style="max-width:420px">
+          <h3 id="plan-selector-title">选择执行方案</h3>
+          <div id="plan-selector-list" class="plan-selector-list"></div>
+          <div id="plan-selector-times-row" class="form-group" style="display:none;margin-top:8px">
+            <label style="font-size:12px">执行次数</label>
+            <input type="number" id="plan-selector-times" class="input" min="1" max="99" value="1" style="width:80px">
+          </div>
+          <div class="modal-actions">
+            <button class="btn" id="btn-plan-selector-cancel">取消</button>
           </div>
         </div>
       </div>
@@ -353,6 +368,31 @@
               <input type="number" id="plan-edit-ship-ge" class="input input-inline input-small" value="-1" min="-1" max="500">
             </div>
             <span class="plan-task-hint">终止条件: -1为不启用</span>
+
+            <!-- 泡澡修理设置 -->
+            <div class="bath-repair-section">
+              <label class="bath-repair-toggle">
+                <input type="checkbox" id="plan-bath-repair-enable">
+                泡澡修理（不使用快修）
+              </label>
+              <div id="bath-repair-config" class="bath-repair-config" style="display:none">
+                <p class="plan-task-hint" style="margin:4px 0 6px">舰船血量低于阈值时自动送入泡澡，等待修理完成后再执行。选中多个编队预设时自动轮换。</p>
+
+                <!-- 默认修理阈值 -->
+                <div class="bath-default-threshold">
+                  <span class="bath-rotation-label">默认阈值:</span>
+                  <select class="input input-inline bath-default-th-type" id="bath-default-th-type">
+                    <option value="percent">百分比</option>
+                    <option value="absolute">绝对值</option>
+                  </select>
+                  <input type="number" class="input input-inline input-small" id="bath-default-th-value" value="50" min="0" max="999">
+                </div>
+
+                <!-- 按舰船名设定阈值（根据选中预设动态生成） -->
+                <div id="bath-ship-thresholds" class="bath-ship-thresholds" style="display:none"></div>
+                <p class="plan-task-hint" style="margin:4px 0 0">点击上方编队预设（可多选）后，此处显示具体舰船阈值设置。</p>
+              </div>
+            </div>
           </div>
 
           <!-- 节点详细设置（可滚动区域） -->
@@ -417,6 +457,7 @@
               <button class="btn btn-small btn-primary" id="btn-create-template">创建模板</button>
             </div>
           </div>
+          <p class="config-hint" style="margin:0 0 8px;font-size:11px">保存可复用的任务参数预设。点击「加入列表」将模板添加到主页任务列表。</p>
           <div class="template-library-items" id="template-library-items">
             <p class="tpl-empty">暂无模板，点击「创建模板」添加</p>
           </div>
@@ -460,11 +501,8 @@
           <div class="input-row">
             <input type="text" id="cfg-emu-serial" class="input" placeholder="如 127.0.0.1:16384，留空自动检测">
             <button class="btn btn-small" id="btn-check-adb">检测 ADB</button>
+            <span id="cfg-adb-status" class="adb-status adb-status-unknown">未检测</span>
           </div>
-        </div>
-        <div class="form-group">
-          <label>ADB 状态</label>
-          <span id="cfg-adb-status" class="adb-status adb-status-unknown">未检测</span>
         </div>
       </div>
 
@@ -513,7 +551,7 @@
 
       <div class="card">
         <h3>自动化设置</h3>
-        <p class="config-hint">勾选启用的自动化任务。后端启动后将按照配置自动执行对应任务。具体任务参数可在模板中进一步自定义。</p>
+        <p class="config-hint">每日自动调度的任务开关。启用后，后端启动时自动执行对应任务。</p>
 
         <div class="auto-grid">
 
@@ -524,7 +562,7 @@
           </div>
           <div class="auto-section-body">
             <div class="form-group">
-              <label>远征检查间隔（分钟）</label>
+              <label>检查间隔（分钟）</label>
               <input type="number" id="cfg-expedition-interval" class="input" min="1" max="120" value="15">
             </div>
           </div>
@@ -552,7 +590,7 @@
               </select>
             </div>
             <div class="form-group">
-              <label>战役次数</label>
+              <label>次数</label>
               <input type="number" id="cfg-battle-times" class="input" min="1" max="10" value="3">
             </div>
           </div>
@@ -582,7 +620,7 @@
             <label class="auto-toggle"><input type="checkbox" id="cfg-auto-normal-fight"> 自动常规出击</label>
           </div>
           <div class="auto-section-body">
-            <p class="config-hint">按模板库中的出击方案自动执行。</p>
+            <p class="config-hint">每日自动执行任务列表中的所有任务。</p>
           </div>
         </div>
 
@@ -592,7 +630,20 @@
             <label class="auto-toggle"><input type="checkbox" id="cfg-auto-decisive"> 自动决战</label>
           </div>
           <div class="auto-section-body">
-            <p class="config-hint">按模板库中的决战配置自动执行。</p>
+            <div class="form-group" style="margin-bottom:6px">
+              <div class="input-row" style="align-items:center;gap:8px">
+                <label style="font-size:12px;white-space:nowrap">保留票数</label>
+                <input type="number" id="cfg-decisive-ticket-reserve" class="input" min="0" value="0" style="width:60px">
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="input-row" style="align-items:center;gap:8px">
+                <label style="font-size:12px;white-space:nowrap">模板</label>
+                <select id="cfg-decisive-template" class="input" style="flex:1;min-width:100px">
+                  <option value="">未选择</option>
+                </select>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -672,11 +723,14 @@
         <!-- 普通出击 -->
         <div class="wizard-config" id="wizard-cfg-normal_fight">
           <div class="form-group">
-            <label>战斗方案文件</label>
-            <div class="input-row">
-              <input type="text" id="tpl-plan-path" class="input" readonly placeholder="点击选择 .yaml 方案文件">
-              <button class="btn btn-small" id="btn-tpl-browse-plan">选择</button>
+            <label>可选方案文件 <small style="color:var(--text-muted)">(可添加多个，使用时选择)</small></label>
+            <div id="tpl-plan-list" class="tpl-plan-list"></div>
+            <div class="input-row" style="margin-top:4px">
+              <button class="btn btn-small" id="btn-tpl-browse-plan">+ 浏览添加</button>
+              <button class="btn btn-small" id="btn-tpl-scan-plans">从方案目录扫描</button>
             </div>
+            <!-- 向后兼容：隐藏的单路径输入 -->
+            <input type="hidden" id="tpl-plan-path">
           </div>
           <div class="form-group">
             <label>编队</label>
@@ -789,7 +843,7 @@
           <label>默认执行次数</label>
           <input type="number" id="tpl-default-times" class="input" value="1" min="1" max="999">
         </div>
-        <div class="form-group">
+        <div class="form-group" id="tpl-stop-condition-group">
           <label>停止条件 (可选)</label>
           <div class="input-row">
             <label style="font-size:12px;white-space:nowrap">战利品 ≥</label>

--- a/src/view/styles.css
+++ b/src/view/styles.css
@@ -117,11 +117,21 @@ body {
 .nav-title {
   font-weight: 700;
   font-size: 15px;
-  margin-right: 36px;
+  margin-right: 18px;
   letter-spacing: -0.01em;
   background: linear-gradient(135deg, var(--accent), var(--accent-hover));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+}
+
+.nav-version {
+  font-size: 12px;
+  font-weight: 500;
+  margin-left: 6px;
+  background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  opacity: 0.75;
 }
 
 .nav-tabs {
@@ -681,6 +691,100 @@ body {
   color: var(--text-muted);
   margin-top: 4px;
   display: block;
+}
+
+/* 泡澡修理设置 */
+.bath-repair-section {
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+  padding-top: 6px;
+}
+
+.bath-repair-toggle {
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.bath-repair-toggle input[type="checkbox"] {
+  margin: 0;
+}
+
+.bath-repair-config {
+  margin-top: 6px;
+}
+
+.bath-default-threshold {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bath-rotation-label {
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.bath-default-threshold .input-inline {
+  font-size: 11px;
+  padding: 2px 4px;
+}
+
+.bath-default-threshold .input-small {
+  width: 60px;
+}
+
+/* 泡澡修理: 按舰船名阈值 */
+.bath-ship-thresholds {
+  margin-top: 6px;
+  border-top: 1px solid var(--border);
+  padding-top: 4px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 2px 6px;
+  align-items: center;
+}
+
+.bath-ship-th-header-row,
+.bath-ship-th-row {
+  display: contents;
+}
+
+.bath-ship-th-label-h {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.bath-ship-th-h {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.bath-ship-th-label {
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.bath-ship-th-type {
+  font-size: 10px;
+  padding: 1px 2px;
+  width: 64px;
+  box-sizing: border-box;
+}
+
+.bath-ship-th-value {
+  width: 40px;
+  font-size: 11px;
+  padding: 2px 3px;
+  box-sizing: border-box;
 }
 
 .fleet-select-label {
@@ -1266,6 +1370,22 @@ body {
 .btn-small {
   padding: 8px 14px;
   font-size: 13px;
+}
+
+.btn-xs {
+  padding: 2px 8px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.btn-outline:hover {
+  background: var(--bg-hover);
+  color: var(--text);
 }
 
 .btn-danger {
@@ -1911,6 +2031,7 @@ select.input {
   display: flex;
   gap: 16px;
   height: calc(100vh - 52px - 32px);
+  align-items: stretch;
 }
 
 .plan-page-main {
@@ -1932,6 +2053,7 @@ select.input {
   display: flex;
   align-items: center;
   justify-content: center;
+  margin-bottom: 0;
 }
 
 .plan-empty-card .empty-state {
@@ -2099,7 +2221,6 @@ input[type="checkbox"]:focus-visible {
 
 /* ═══ 配置页布局 ═══ */
 #page-config {
-  max-height: calc(100vh - 52px - 40px);
   overflow: hidden;
 }
 
@@ -2107,7 +2228,7 @@ input[type="checkbox"]:focus-visible {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .config-header-actions {
@@ -2125,19 +2246,19 @@ input[type="checkbox"]:focus-visible {
 .config-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
 }
 
 .config-col-left {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .config-col-right {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 .config-col-right > .card {
@@ -2148,45 +2269,55 @@ input[type="checkbox"]:focus-visible {
 
 .config-grid .card {
   margin-bottom: 0;
-  padding: 16px 20px;
+  padding: 12px 16px;
 }
 
 .config-grid .card h3 {
-  margin-bottom: 12px;
+  margin-bottom: 8px;
+  font-size: 14px;
 }
 
 .config-grid .form-group {
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .config-grid .form-group:last-child {
   margin-bottom: 0;
 }
 
+.config-grid .form-group > label {
+  font-size: 12px;
+}
+
+.config-grid .input {
+  padding: 6px 10px;
+  font-size: 12px;
+}
+
 /* 自动化分区 */
 .auto-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 12px 20px;
+  gap: 8px 12px;
   flex: 1;
   align-content: start;
 }
 
 .auto-section {
   margin-bottom: 0;
-  padding: 10px 12px;
+  padding: 8px 10px;
   border-radius: var(--radius);
   border: 1px solid var(--border);
   background: var(--bg-card);
 }
 
 .auto-section-header {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 
 .auto-toggle {
   font-weight: 600;
-  font-size: 13px;
+  font-size: 12px;
   cursor: pointer;
 }
 
@@ -2196,10 +2327,11 @@ input[type="checkbox"]:focus-visible {
 
 .auto-section-body {
   padding-left: 4px;
+  font-size: 12px;
 }
 
 .auto-section-body .form-group {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 
 .auto-section-body .form-group:last-child {
@@ -2229,10 +2361,10 @@ input[type="checkbox"]:focus-visible {
 }
 
 .config-hint {
-  font-size: 12px;
+  font-size: 11px;
   color: var(--text-muted);
-  margin: 0 0 8px 0;
-  line-height: 1.5;
+  margin: 0 0 6px 0;
+  line-height: 1.4;
 }
 
 /* ═══ 队列操作栏 ═══ */
@@ -2516,6 +2648,87 @@ input[type="checkbox"]:focus-visible {
   display: flex;
   gap: 4px;
   flex-shrink: 0;
+}
+
+/* ═══ 模板向导：多方案列表 ═══ */
+.tpl-plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+.tpl-plan-entry {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--surface);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+.tpl-plan-entry .plan-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.tpl-plan-entry .btn-remove-plan {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+}
+.tpl-plan-entry .btn-remove-plan:hover {
+  color: var(--danger);
+}
+
+/* 内置模板标识 */
+.tpl-builtin-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--accent);
+  color: #fff;
+  margin-left: 6px;
+  vertical-align: middle;
+  font-weight: 500;
+}
+
+/* ═══ 方案选择器弹窗 ═══ */
+.plan-selector-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 320px;
+  overflow-y: auto;
+  margin: 12px 0;
+  padding: 2px;
+}
+.plan-selector-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.15s, box-shadow 0.15s;
+  font-size: 13px;
+}
+.plan-selector-item:hover {
+  background: var(--bg-hover);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.plan-selector-item .plan-icon {
+  flex-shrink: 0;
+  width: 20px;
+  text-align: center;
+  color: var(--accent);
 }
 
 /* ═══ 右键上下文菜单 ═══ */

--- a/src/view/viewObjects.ts
+++ b/src/view/viewObjects.ts
@@ -130,6 +130,8 @@ export interface ConfigViewObject {
   battleTimes: number;
   autoNormalFight: boolean;
   autoDecisive: boolean;
+  decisiveTicketReserve: number;
+  decisiveTemplateId: string;
   themeMode: 'dark' | 'light' | 'system';
   accentColor: string;
   debugMode: boolean;

--- a/task_groups.json
+++ b/task_groups.json
@@ -1,33 +1,9 @@
 {
-  "activeGroup": "8-5AI",
+  "activeGroup": "干了xdm",
   "groups": [
     {
-      "name": "9-2捞胖次",
-      "items": [
-        {
-          "path": "E:\\wsgrgui\\plans\\9-2捞胖次.yaml",
-          "kind": "plan",
-          "times": 9999,
-          "label": "9-2捞胖次"
-        }
-      ]
-    },
-    {
-      "name": "8-5AI",
-      "items": [
-        {
-          "path": "E:\\wsgrgui\\plans\\9-2捞胖次.yaml",
-          "kind": "plan",
-          "times": 9999,
-          "label": "9-2捞胖次"
-        },
-        {
-          "path": "E:\\wsgrgui\\plans\\8-5AI.yaml",
-          "kind": "plan",
-          "times": 1,
-          "label": "8-5AI"
-        }
-      ]
+      "name": "干了xdm",
+      "items": []
     }
   ]
 }


### PR DESCRIPTION
## 概述

实现编队预设轮换与自动泡澡修理系统，以及模板系统增强。

## 新增功能

### 泡澡修理系统
- **RepairManager** (src/model/RepairManager.ts): 泡澡修理管理器
  - 按舰船名匹配阈值（支持默认阈值 + 按舰船覆盖）
  - 跟踪泡澡状态，自动清除已修复舰船记录
  - 舰船名格式归一化（\	oBackendName\），兼容 UI 显示名与后端名
- **Scheduler 集成**: 任务执行前自动检查编队血量，需修理时送入泡澡并延迟任务
- **前端 UI**: 泡澡修理开关 + 默认阈值 + 按舰船自定义阈值（从选中预设动态生成）

### 编队预设轮换
- **多选编队预设**: 点击选择多个编队预设（\Set<number>\）
- **自动轮换**: 当前编队舰船在泡澡时，自动切换到另一套没有舰船在修的预设继续战斗
- **延迟任务机制**: 所有预设都有船在修时，任务延迟 30s 后重试（不消耗 \emainingTimes\）

### 模板系统增强
- 内置模板库（\esource/builtin_templates.json\）
- 内置/用户模板分离
- CronScheduler 任务组定时调度增强

## Bug 修复
- 舰船名格式不匹配: \athingShips\ 用后端名、preset 用显示名导致比较不匹配
- 修好的舰船未从 \athingShips\ 清除导致预设永久不可用
- \leetId\ 未定义时泡澡修理静默跳过（默认为 1）
- CSS: \.btn-xs\ / \.btn-outline\ 类未定义导致按钮过大
- CSS: 泡澡舰船阈值 grid 布局对齐问题

## 后端依赖
此 PR 需要 AutoWSGR 后端添加 \POST /api/repair/ship\ 路由（调用已有的 \epair_ship_by_name\ 函数）。