### PR TITLE
修复决战模板加入队列后执行轮数失效

### DIFF
--- a/src/controller/taskGroup/queueLoader.ts
+++ b/src/controller/taskGroup/queueLoader.ts
@@ -102,7 +102,7 @@ export function loadTemplateToQueue(
         flagship_priority: tpl.flagship_priority ?? [],
         use_quick_repair: tpl.use_quick_repair,
       };
-      host.scheduler.addTask(item.label || tpl.name, 'decisive', req, TaskPriority.USER_TASK, 1);
+      host.scheduler.addTask(item.label || tpl.name, 'decisive', req, TaskPriority.USER_TASK, times);
       break;
     default:
       return false;


### PR DESCRIPTION
## 摘要

修复 GUI 中决战模板加入调度队列后，用户设置的执行轮数没有生效的问题。

## 问题现象

GUI 已经允许用户在使用决战模板时设置执行轮数，并且该轮数会保存到任务组条目的 `times` 字段。

但实际加载到调度队列后，决战任务始终只执行 1 轮。

## 根因

在 `src/controller/taskGroup/queueLoader.ts` 中，决战模板分支虽然正确构造了 `decisive` 请求，但在调用 `host.scheduler.addTask(...)` 时，把调度器重复次数写死成了 `1`，没有使用条目中的 `times`。

## 修复内容

将决战模板分支改为把 `times` 传给 `host.scheduler.addTask(...)`，从而直接复用前端现有调度器的重复执行机制。

## 说明

这是一个纯前端修复：

- 不依赖后端新增字段
- 与前端现有重复任务执行机制保持一致
- 对接旧版后端时也能正常工作

Closes #6
