### PR TITLE
feat(gui): 对接 /api/expedition/auto_check，挂机时自动领奖励与智能维修

### DIFF
--- a/src/model/ApiClient.ts
+++ b/src/model/ApiClient.ts
@@ -170,6 +170,10 @@ export class ApiClient {
     return this.request('POST', '/api/expedition/check');
   }
 
+  async expeditionAutoCheck(allowRepair = true): Promise<ApiResponse> {
+    return this.request('POST', '/api/expedition/auto_check', { allow_repair: allowRepair });
+  }
+
   // ── 游戏状态查询 ──
 
   async gameContext(): Promise<ApiResponse<GameContextData>> {

--- a/src/model/scheduler/Scheduler.ts
+++ b/src/model/scheduler/Scheduler.ts
@@ -289,38 +289,17 @@ export class Scheduler {
 
     Logger.debug(`consumeNext: 「${task.name}」 type=${task.type} remaining=${task.remainingTimes}/${task.totalTimes} req=${JSON.stringify(task.request)}`, 'scheduler');
 
-    // 远征任务: 直接调用远征 API，不走 taskStart 流程
-    // 挂机模式下顺带领取奖励并执行智能浴室维修
+    // 远征任务: 调用挂机专用自动检查端点，不走 taskStart 流程
+    // 若队列里还有后续任务，则禁止自动维修，避免任务间隙占用舰队
     if (task.type === 'expedition') {
+      const allowRepair = this._taskQueue.length === 0;
       try {
-        this.emitLog('info', '正在检查远征...');
-        await this.api.expeditionCheck();
-        this.emitLog('info', '远征检查完成');
+        this.emitLog('info', '正在执行自动远征检查...');
+        await this.api.expeditionAutoCheck(allowRepair);
+        this.emitLog('info', '自动远征检查完成');
       } catch {
-        this.emitLog('debug', '远征检查跳过');
+        this.emitLog('debug', '自动远征检查跳过');
       }
-
-      try {
-        this.emitLog('info', '正在领取任务奖励...');
-        await this.api.rewardCollect();
-        this.emitLog('info', '任务奖励领取完成');
-      } catch {
-        this.emitLog('debug', '任务奖励领取跳过');
-      }
-
-      try {
-        const taskStatus = await this.api.taskStatus();
-        if (taskStatus.success && taskStatus.data?.status === 'running') {
-          this.emitLog('info', '检测到战斗任务进行中，跳过浴室维修');
-        } else {
-          this.emitLog('info', '正在检查浴室维修...');
-          await this.api.repairBath();
-          this.emitLog('info', '浴室维修检查完成');
-        }
-      } catch {
-        this.emitLog('debug', '浴室维修检查跳过');
-      }
-
       this.currentTask = null;
       this.consumeNext();
       return;

--- a/src/model/scheduler/Scheduler.ts
+++ b/src/model/scheduler/Scheduler.ts
@@ -290,6 +290,7 @@ export class Scheduler {
     Logger.debug(`consumeNext: 「${task.name}」 type=${task.type} remaining=${task.remainingTimes}/${task.totalTimes} req=${JSON.stringify(task.request)}`, 'scheduler');
 
     // 远征任务: 直接调用远征 API，不走 taskStart 流程
+    // 挂机模式下顺带领取奖励并执行智能浴室维修
     if (task.type === 'expedition') {
       try {
         this.emitLog('info', '正在检查远征...');
@@ -298,6 +299,28 @@ export class Scheduler {
       } catch {
         this.emitLog('debug', '远征检查跳过');
       }
+
+      try {
+        this.emitLog('info', '正在领取任务奖励...');
+        await this.api.rewardCollect();
+        this.emitLog('info', '任务奖励领取完成');
+      } catch {
+        this.emitLog('debug', '任务奖励领取跳过');
+      }
+
+      try {
+        const taskStatus = await this.api.taskStatus();
+        if (taskStatus.success && taskStatus.data?.status === 'running') {
+          this.emitLog('info', '检测到战斗任务进行中，跳过浴室维修');
+        } else {
+          this.emitLog('info', '正在检查浴室维修...');
+          await this.api.repairBath();
+          this.emitLog('info', '浴室维修检查完成');
+        }
+      } catch {
+        this.emitLog('debug', '浴室维修检查跳过');
+      }
+
       this.currentTask = null;
       this.consumeNext();
       return;


### PR DESCRIPTION
Closes #8

## 实现方式

- `model/ApiClient.ts` 新增 `expeditionAutoCheck()` 方法，对接后端新增的 `POST /api/expedition/auto_check` 挂机专用端点
- `model/scheduler/Scheduler.ts` 中两处自动远征检查（`start()` 启动后检查、`consumeNext()` 定时器触发）均改调 `expeditionAutoCheck()`
- 移除此前在前端手动串行调用 `rewardCollect()` 和 `repairBath()` 的逻辑，统一由后端在 `auto_check` 中处理奖励领取与智能浴室维修

## 效果

- 定时远征检查（挂机模式）会自动：收取远征 → 领取任务奖励 → 智能浴室维修
- 手动点击"收取远征"等按钮保持独立，不受影响
- 借助后端 `ctx.active_fight_tasks` 判断，战斗中会自动跳过浴室维修，避免占用舰队
