### PR TITLE
fix: align frontend with backend 2.3.0

### DIFF
--- a/src/controller/plan/PlanController.ts
+++ b/src/controller/plan/PlanController.ts
@@ -253,7 +253,17 @@ export class PlanController {
     if (args.proceed_stop != null) mapped.proceed_stop = args.proceed_stop;
     if (args.SL_when_detour_fails != null) mapped.SL_when_detour_fails = args.SL_when_detour_fails;
     if (args.enemy_rules && args.enemy_rules.length > 0) {
-      mapped.enemy_rules = args.enemy_rules.map(([cond, action]) => [String(cond), String(action)]);
+      mapped.enemy_rules = args.enemy_rules.map(([cond, action]) => [String(cond), action]);
+    }
+    if (args.enemy_formation_rules && args.enemy_formation_rules.length > 0) {
+      mapped.enemy_formation_rules = args.enemy_formation_rules.map(([cond, action]) => [String(cond), action]);
+    }
+    if (args.SL_when_spot_enemy_fails != null) {
+      mapped.SL_when_spot_enemy_fails = args.SL_when_spot_enemy_fails;
+    }
+    if (args.SL_when_enter_fight != null) mapped.SL_when_enter_fight = args.SL_when_enter_fight;
+    if (args.formation_when_spot_enemy_fails != null) {
+      mapped.formation_when_spot_enemy_fails = args.formation_when_spot_enemy_fails;
     }
     return Object.keys(mapped).length > 0 ? mapped : undefined;
   }
@@ -357,7 +367,8 @@ export class PlanController {
         if (!req.plan) req.plan = {};
         req.plan.fleet = resolved.map(toBackendName);
         req.plan.fleet_id = effectiveFleetId;
-        req.plan.fleet_rules = resolveFleetPresetRules(firstPreset.ships);
+        const fleetRules = resolveFleetPresetRules(firstPreset.ships);
+        if (fleetRules.length > 0) req.plan.fleet_rules = fleetRules;
       }
     }
 

--- a/src/controller/plan/nodeEditor.ts
+++ b/src/controller/plan/nodeEditor.ts
@@ -3,12 +3,12 @@
  */
 import type { PlanPreviewView } from '../../view/plan/PlanPreviewView';
 import type { PlanModel } from '../../model/PlanModel';
-import type { EnemyRule } from '../../types/model';
+import type { EnemyRule, RuleAction } from '../../types/model';
 import { Logger } from '../../utils/Logger';
 
-function normalizeRuleAction(actionRaw: string): string | number {
+function normalizeRuleAction(actionRaw: string): RuleAction | null {
   const trimmed = actionRaw.trim();
-  if (!trimmed) return trimmed;
+  if (!trimmed) return null;
 
   const aliases: Record<string, string> = {
     detour: 'detour',
@@ -20,9 +20,10 @@ function normalizeRuleAction(actionRaw: string): string | number {
   const lower = trimmed.toLowerCase();
   const normalized = aliases[lower] ?? aliases[trimmed] ?? trimmed;
   if (/^\d+$/.test(normalized)) {
-    return Number(normalized);
+    const value = Number(normalized);
+    return value >= 1 && value <= 5 ? (value as RuleAction) : null;
   }
-  return normalized;
+  return normalized === 'retreat' || normalized === 'detour' ? normalized : null;
 }
 
 function parseRuleLine(rawLine: string): EnemyRule | null {
@@ -44,7 +45,8 @@ function parseRuleLine(rawLine: string): EnemyRule | null {
   }
 
   if (!expr || !action) return null;
-  return [expr, normalizeRuleAction(action)];
+  const normalizedAction = normalizeRuleAction(action);
+  return normalizedAction === null ? null : [expr, normalizedAction];
 }
 
 /**

--- a/src/controller/taskGroup/queueLoader.ts
+++ b/src/controller/taskGroup/queueLoader.ts
@@ -67,7 +67,8 @@ export async function loadGroupToQueue(
             if (resolved.length > 0) {
               req.plan = req.plan ?? {};
               req.plan.fleet = resolved.map(toBackendName);
-              req.plan.fleet_rules = resolveFleetPresetRules(preset.ships);
+              const rules = resolveFleetPresetRules(preset.ships);
+              if (rules.length > 0) req.plan.fleet_rules = rules;
             }
           }
         }
@@ -201,7 +202,8 @@ export async function loadSingleItemToQueue(
           if (resolved.length > 0) {
             req.plan = req.plan ?? {};
             req.plan.fleet = resolved.map(toBackendName);
-            req.plan.fleet_rules = resolveFleetPresetRules(preset.ships);
+            const rules = resolveFleetPresetRules(preset.ships);
+            if (rules.length > 0) req.plan.fleet_rules = rules;
           }
         }
       }

--- a/src/data/shipData.ts
+++ b/src/data/shipData.ts
@@ -12,18 +12,31 @@ export interface ShipInfo {
 // ship_type 代号 → 中文
 export const TYPE_LABELS: Record<string, string> = {
   bb: '战列', bbv: '航战', bbg: '导战',
-  bc: '战巡', cbg: '大巡',
+  bc: '战巡', bg: '大巡', cbg: '大巡',
   cv: '航母', cvl: '轻母', av: '装母',
   ca: '重巡', cav: '航巡',
   cl: '轻巡', clt: '雷巡', cf: '旗舰',
   dd: '驱逐', ddg: '导驱', ddgaa: '防驱',
   ss: '潜艇', sc: '炮潜', ssg: '导潜',
   ss_or_ssg: '潜艇/导潜',
-  bm: '重炮', ap: '补给', cg: '导巡', cgaa: '防巡',
+  bm: '重炮', ap: '补给', asdg: '导驱', aadg: '防驱', cg: '防巡', kp: '导巡', cgaa: '防巡',
 };
 
 export function shipTypeLabel(code: string): string {
   return TYPE_LABELS[code] || code;
+}
+
+/** 将旧版 GUI 舰种代码转换为后端 2.3.x canonical code。 */
+export function toBackendShipTypeCode(code: string): string {
+  const aliases: Record<string, string> = {
+    cf: 'cv',
+    cgaa: 'cg',
+    cbg: 'bg',
+    ddg: 'asdg',
+    ddgaa: 'aadg',
+  };
+  const normalized = code.trim().toLowerCase();
+  return aliases[normalized] ?? normalized;
 }
 
 import rawShips from './ship_details.json';
@@ -209,7 +222,7 @@ export function resolveFleetPresetRules(ships: ShipSlot[]): Array<string | Fleet
       if (searchName) rule.search_name = searchName;
     }
     if (slot.ship_type) {
-      rule.ship_type = String(slot.ship_type).trim();
+      rule.ship_type = toBackendShipTypeCode(String(slot.ship_type));
     }
     if (slot.min_level != null && Number.isFinite(slot.min_level)) {
       rule.min_level = Math.max(1, Math.floor(slot.min_level));

--- a/src/model/PlanModel.ts
+++ b/src/model/PlanModel.ts
@@ -198,6 +198,16 @@ export class PlanModel {
     if (args.detour != null) out.detour = args.detour;
     if (args.SL_when_detour_fails != null) out.SL_when_detour_fails = args.SL_when_detour_fails;
     if (args.enemy_rules && args.enemy_rules.length > 0) out.enemy_rules = args.enemy_rules;
+    if (args.enemy_formation_rules && args.enemy_formation_rules.length > 0) {
+      out.enemy_formation_rules = args.enemy_formation_rules;
+    }
+    if (args.SL_when_spot_enemy_fails != null) {
+      out.SL_when_spot_enemy_fails = args.SL_when_spot_enemy_fails;
+    }
+    if (args.SL_when_enter_fight != null) out.SL_when_enter_fight = args.SL_when_enter_fight;
+    if (args.formation_when_spot_enemy_fails != null) {
+      out.formation_when_spot_enemy_fails = args.formation_when_spot_enemy_fails;
+    }
     if (args.proceed_stop) out.proceed_stop = args.proceed_stop;
     return out;
   }
@@ -248,13 +258,14 @@ export class PlanModel {
     return String(raw);
   }
 
-  private static normalizeRuleAction(actionRaw: unknown): string | number {
+  private static normalizeRuleAction(actionRaw: unknown): EnemyRule[1] | null {
     if (typeof actionRaw === 'number' && Number.isFinite(actionRaw)) {
-      return Math.trunc(actionRaw);
+      const value = Math.trunc(actionRaw);
+      return value >= 1 && value <= 5 ? (value as EnemyRule[1]) : null;
     }
 
     const raw = String(actionRaw ?? '').trim();
-    if (!raw) return raw;
+    if (!raw) return null;
 
     const aliases: Record<string, string> = {
       detour: 'detour',
@@ -266,9 +277,12 @@ export class PlanModel {
     const lower = raw.toLowerCase();
     const normalized = aliases[lower] ?? aliases[raw] ?? raw;
     if (/^\d+$/.test(normalized)) {
-      return Number(normalized);
+      const value = Number(normalized);
+      return value >= 1 && value <= 5 ? (value as EnemyRule[1]) : null;
     }
-    return normalized;
+    return normalized === 'retreat' || normalized === 'detour'
+      ? normalized
+      : null;
   }
 
   private static normalizeEnemyRules(rules: unknown): EnemyRule[] | undefined {
@@ -280,6 +294,7 @@ export class PlanModel {
       const expr = String(item[0] ?? '').trim();
       if (!expr) continue;
       const action = PlanModel.normalizeRuleAction(item[1]);
+      if (action === null) continue;
       normalized.push([expr, action]);
     }
 
@@ -290,6 +305,7 @@ export class PlanModel {
     if (!args) return undefined;
     const normalized: NodeArgs = { ...args };
     normalized.enemy_rules = PlanModel.normalizeEnemyRules(args.enemy_rules);
+    normalized.enemy_formation_rules = PlanModel.normalizeEnemyRules(args.enemy_formation_rules);
     return normalized;
   }
 

--- a/src/model/scheduler/TaskQueue.ts
+++ b/src/model/scheduler/TaskQueue.ts
@@ -266,11 +266,15 @@ export class TaskQueue {
       const fleet = resolved.map(toBackendName);
       const fleetRules = resolveFleetPresetRules(preset.ships);
       if (req.plan) {
-        req.plan.fleet = fleet;
-        req.plan.fleet_rules = fleetRules;
+        if (fleet.length > 0) req.plan.fleet = fleet;
+        if (fleetRules.length > 0) req.plan.fleet_rules = fleetRules;
         req.plan.fleet_id = task.fleetId;
       } else {
-        (req as any).plan = { fleet, fleet_rules: fleetRules, fleet_id: task.fleetId };
+        (req as any).plan = {
+          ...(fleet.length > 0 ? { fleet } : {}),
+          ...(fleetRules.length > 0 ? { fleet_rules: fleetRules } : {}),
+          fleet_id: task.fleetId,
+        };
       }
       if (req.type === 'event_fight') req.fleet_id = task.fleetId;
     }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -154,8 +154,14 @@ export interface NodeDecisionReq {
   proceed_stop?: number[];
   detour?: boolean;
   SL_when_detour_fails?: boolean;
-  enemy_rules?: string[][] | null;
+  enemy_rules?: Array<[string, RuleAction]> | null;
+  enemy_formation_rules?: Array<[string, RuleAction]> | null;
+  SL_when_spot_enemy_fails?: boolean;
+  SL_when_enter_fight?: boolean;
+  formation_when_spot_enemy_fails?: number | null;
 }
+
+export type RuleAction = 'retreat' | 'detour' | 1 | 2 | 3 | 4 | 5;
 
 export interface FleetRuleReq {
   /** 候选舰船名（按优先级顺序） */

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -8,7 +8,8 @@
 // ════════════════════════════════════════
 
 /** 索敌规则条目: [条件表达式, 动作] */
-export type EnemyRule = [string, string | number];
+export type RuleAction = 'retreat' | 'detour' | 1 | 2 | 3 | 4 | 5;
+export type EnemyRule = [string, RuleAction];
 
 /** 单个节点的战斗参数 */
 export interface NodeArgs {
@@ -21,6 +22,10 @@ export interface NodeArgs {
   detour?: boolean;
   proceed_stop?: number[];         // 6 个元素
   SL_when_detour_fails?: boolean;
+  SL_when_spot_enemy_fails?: boolean;
+  SL_when_enter_fight?: boolean;
+  formation_when_spot_enemy_fails?: number | null;
+  enemy_formation_rules?: EnemyRule[];
 }
 
 /** 舰船筛选条件 (按舰名/国籍/舰种选船) */


### PR DESCRIPTION
## Summary

Align the GUI request/model layer with backend `AutoWSGR 2.3.0`.

## Changes

- Preserve and serialize backend node decision fields:
  - `enemy_formation_rules`
  - `SL_when_spot_enemy_fails`
  - `SL_when_enter_fight`
  - `formation_when_spot_enemy_fails`
- Restrict frontend rule actions to `retreat`, `detour`, and formations `1..5`.
- Drop malformed/unsupported rule actions before sending requests.
- Normalize legacy ship-type aliases to backend canonical codes:
  - `cf -> cv`
  - `cgaa -> cg`
  - `cbg -> bg`
  - `ddg -> asdg`
  - `ddgaa -> aadg`
- Avoid sending empty `fleet` / `fleet_rules` overrides, which backend 2.3.0 rejects.
- Keep candidate-only fleet rules with `search_name` and inherited constraints compatible.

## Verification

- `npm run build` passes.
- `git diff --check` passes.

The four modified activity YAML files were pre-existing local changes and are intentionally excluded from this PR.