### PR TITLE
fix: run expeditions between repeated combat rounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wsgrgui",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wsgrgui",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "dependencies": {
         "electron-updater": "^6.8.3",
         "js-yaml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wsgrgui",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "AutoWSGR 图形界面 — MVP",
   "main": "dist/electron/main.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "clean": "node -e \"fs.rmSync('dist/src',{recursive:true,force:true});fs.rmSync('dist/electron',{recursive:true,force:true});console.log('dist cleaned')\" ",
     "build": "npm run clean && npm run build:css && tsc && node scripts/bundle.js",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && node scripts/test-ship-library-contract.js",
+    "test": "npm run build && node scripts/test-ship-library-contract.js && node scripts/test-scheduler-round-boundary.js",
     "start": "chcp 65001 >nul && npm run build && electron .",
     "dev": "chcp 65001 >nul && npm run clean && npm run build:css && tsc && node scripts/bundle.js && electron .",
     "prepare-python": "node scripts/prepare-python.js",

--- a/scripts/test-scheduler-round-boundary.js
+++ b/scripts/test-scheduler-round-boundary.js
@@ -1,0 +1,139 @@
+const assert = require('assert/strict');
+const path = require('path');
+
+const storage = new Map();
+global.localStorage = {
+  getItem: key => storage.get(key) ?? null,
+  setItem: (key, value) => storage.set(key, String(value)),
+  removeItem: key => storage.delete(key),
+  clear: () => storage.clear(),
+};
+
+const projectRoot = path.join(__dirname, '..');
+const { Scheduler } = require(path.join(projectRoot, 'dist', 'src', 'model', 'scheduler', 'Scheduler.js'));
+const { TaskPriority } = require(path.join(projectRoot, 'dist', 'src', 'types', 'scheduler.js'));
+
+const flush = () => new Promise(resolve => setImmediate(resolve));
+
+class FakeApi {
+  constructor() {
+    this.callbacks = {};
+    this.started = [];
+    this.calls = [];
+    this.stopCalls = 0;
+  }
+
+  setCallbacks(callbacks) {
+    this.callbacks = callbacks;
+  }
+
+  async taskStart(request) {
+    this.started.push(request);
+    this.calls.push(request.type);
+    return { success: true, data: { task_id: `backend_${this.started.length}` } };
+  }
+
+  async taskStop() {
+    this.stopCalls++;
+    this.calls.push('taskStop');
+    return { success: true };
+  }
+
+  async expeditionCheck() {
+    this.calls.push('expedition');
+    return { success: true };
+  }
+
+  async rewardCollect() {
+    return { success: true };
+  }
+
+  async gameContext() {
+    return { success: true, data: { fleets: [] } };
+  }
+}
+
+function makeScheduler(api) {
+  const scheduler = new Scheduler(api);
+  scheduler.setStatus('idle');
+  return scheduler;
+}
+
+async function verifySingleRoundRequests() {
+  const cases = [
+    ['normal_fight', { type: 'normal_fight', times: 4, gap: 0 }],
+    ['event_fight', { type: 'event_fight', times: 4, gap: 0, fleet_id: 1 }],
+    ['campaign', { type: 'campaign', campaign_name: '困难潜艇', times: 4 }],
+  ];
+
+  for (const [type, request] of cases) {
+    const api = new FakeApi();
+    const scheduler = makeScheduler(api);
+    scheduler.addTask(type, type, request, TaskPriority.USER_TASK, 2);
+
+    assert.equal(scheduler.taskQueue[0].remainingTimes, 4, `${type} must preserve the legacy logical total`);
+    assert.equal(scheduler.taskQueue[0].totalTimes, 4, `${type} must display the legacy logical total`);
+
+    scheduler.startConsuming();
+    await flush();
+    assert.equal(api.started[0].times, 1, `${type} backend request must run one round`);
+
+    api.callbacks.onTaskCompleted({ type: 'task_completed', task_id: 'backend_1', success: true });
+    await flush();
+    assert.equal(api.started[1].times, 1, `${type} follow-up request must run one round`);
+  }
+
+  const api = new FakeApi();
+  const scheduler = makeScheduler(api);
+  scheduler.addTask(
+    'scheduler total',
+    'normal_fight',
+    { type: 'normal_fight', times: 2, gap: 0 },
+    TaskPriority.USER_TASK,
+    5,
+  );
+  assert.equal(scheduler.taskQueue[0].totalTimes, 5, 'scheduler total must win when it is larger');
+}
+
+async function verifyExpeditionRoundBoundary() {
+  const api = new FakeApi();
+  const scheduler = makeScheduler(api);
+  scheduler.addTask(
+    '十轮出击',
+    'normal_fight',
+    { type: 'normal_fight', times: 10, gap: 0 },
+    TaskPriority.USER_TASK,
+    1,
+  );
+
+  scheduler.startConsuming();
+  await flush();
+  assert.deepEqual(api.calls, ['normal_fight']);
+
+  api.callbacks.onTaskCompleted({ type: 'task_completed', task_id: 'backend_1', success: true });
+  await flush();
+  assert.deepEqual(api.calls, ['normal_fight', 'normal_fight']);
+  assert.equal(scheduler.currentRunningTask.remainingTimes, 9);
+
+  scheduler.handleExpeditionTrigger();
+  assert.equal(api.stopCalls, 0, 'queuing an expedition must not stop the active round');
+  assert.equal(scheduler.taskQueue[0].type, 'expedition');
+
+  api.callbacks.onTaskCompleted({ type: 'task_completed', task_id: 'backend_2', success: true });
+  await flush();
+  await flush();
+
+  assert.deepEqual(api.calls, ['normal_fight', 'normal_fight', 'expedition', 'normal_fight']);
+  assert.equal(api.stopCalls, 0, 'round-boundary expedition scheduling must never call taskStop');
+  assert.equal(scheduler.currentRunningTask.remainingTimes, 8);
+  assert.equal(api.started[2].times, 1);
+}
+
+(async () => {
+  await verifySingleRoundRequests();
+  await verifyExpeditionRoundBoundary();
+  console.log('scheduler round-boundary contract verified');
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/model/scheduler/TaskQueue.ts
+++ b/src/model/scheduler/TaskQueue.ts
@@ -25,6 +25,30 @@ export function parseUiCount(msg: string, label: string): number | null {
   return m ? parseInt(m[1], 10) : null;
 }
 
+/** Split repeatable backend requests into scheduler-owned single-round tasks. */
+export function normalizeRoundTask(
+  type: SchedulerTaskType,
+  request: TaskRequest,
+  times: number,
+): { request: TaskRequest; times: number } {
+  const schedulerTimes = Number.isFinite(times) ? Math.max(1, Math.trunc(times)) : 1;
+  const isRoundBased = type === 'normal_fight' || type === 'event_fight' || type === 'campaign';
+  const hasRoundRequest = request.type === 'normal_fight'
+    || request.type === 'event_fight'
+    || request.type === 'campaign';
+  if (!isRoundBased || !hasRoundRequest) {
+    return { request, times: schedulerTimes };
+  }
+
+  const requestTimes = Number.isFinite(request.times)
+    ? Math.max(1, Math.trunc(request.times ?? 1))
+    : 1;
+  return {
+    request: { ...request, times: 1 },
+    times: Math.max(schedulerTimes, requestTimes),
+  };
+}
+
 // ════════════════════════════════════════
 // TaskQueue 实现
 // ════════════════════════════════════════
@@ -108,14 +132,15 @@ export class TaskQueue {
     sortKey?: number,
   ): string {
     const id = generateTaskId();
+    const normalized = normalizeRoundTask(type, request, times);
     const task: SchedulerTask = {
       id,
       name,
       type,
       priority,
-      request,
-      remainingTimes: times,
-      totalTimes: times,
+      request: normalized.request,
+      remainingTimes: normalized.times,
+      totalTimes: normalized.times,
       stopCondition,
       maxRetries: 2,
       retryCount: 0,


### PR DESCRIPTION
## Summary
- normalize normal/event/campaign repetition into one backend round per scheduler task
- preserve legacy request.times as the logical total count
- let queued expedition checks run immediately after the active round, then resume remaining rounds
- bump GUI version to 1.4.4

## Safety
- does not call taskStop for expedition preemption
- does not include the in-progress intensify UI changes

## Verification
- npm test
- npm run typecheck
- git diff --check